### PR TITLE
ci: PRでもcheckを実行するように変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Check and Deploy
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   check:
@@ -30,7 +32,7 @@ jobs:
   deploy:
     needs: check
     runs-on: ubuntu-latest
-    if: success()
+    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Trigger deploy webhook
         run: |


### PR DESCRIPTION
## Summary
- PRに対しても `pnpm check` を実行し、マージ前にエラーを検出できるようにする
- deployジョブはmainへのpush時のみ実行（PRでは実行しない）

## Test plan
- [x] check失敗時にdeployがスキップされることを確認済み（PR #1で検証）
- [x] check成功 → deploy成功の流れを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)