### PR TITLE
feat: progress通知をEmbed、result通知をプレーンテキストに変更

### DIFF
--- a/server/src/__tests__/integration.test.ts
+++ b/server/src/__tests__/integration.test.ts
@@ -206,15 +206,17 @@ describe('統合テスト', () => {
       sendUserMessage(ctx, 'テストを書いて');
       expect(ctx.orchestrator.state).toBe('busy');
       expect(ctx.mockSpawnFn).toHaveBeenCalledTimes(1);
-      // started 通知
+      // started 通知 (Embed)
       expect(ctx.sent).toHaveLength(2);
-      expect(ctx.sent[1].content).toBe('📨 受信しました。処理を開始します...');
+      const startedEmbed = ctx.sent[1].content as SendOptions;
+      expect(startedEmbed.embeds[0].description).toBe('📨 受信しました。処理を開始します...');
 
-      // 3. tool_use 進捗
+      // 3. tool_use 進捗 (Embed)
       const proc = latestProcess(ctx);
       sendToolUse(proc, 'Edit', 'src/app.ts');
       expect(ctx.sent).toHaveLength(3);
-      expect(ctx.sent[2].content).toBe('🔧 Edit: src/app.ts');
+      const toolEmbed = ctx.sent[2].content as SendOptions;
+      expect(toolEmbed.embeds[0].description).toBe('🔧 Edit: src/app.ts');
 
       // 4. 結果 + 終了
       sendResult(proc, '完了しました');
@@ -224,11 +226,11 @@ describe('統合テスト', () => {
       expect(ctx.orchestrator.state).toBe('idle');
       expect(ctx.usageFetcher.fetch).toHaveBeenCalledTimes(1);
 
-      // result + usage → Embed で送信される
-      const lastSent = ctx.sent[ctx.sent.length - 1].content as SendOptions;
-      expect(lastSent.embeds).toHaveLength(1);
-      expect(lastSent.embeds[0].description).toBe('完了しました');
-      expect(lastSent.embeds[0].color).toBe(0x00c853);
+      // result + usage → プレーンテキストで送信される
+      const resultMsg = ctx.sent.find(
+        (s) => typeof s.content === 'string' && s.content === '完了しました',
+      );
+      expect(resultMsg).toBeDefined();
     });
 
     it('新セッションでは resume=false で spawn される', () => {
@@ -359,8 +361,10 @@ describe('統合テスト', () => {
       await waitForUsage();
 
       expect(ctx.orchestrator.state).toBe('idle');
-      const lastSent = ctx.sent[ctx.sent.length - 1].content as SendOptions;
-      expect(lastSent.embeds[0].description).toBe('続きの結果');
+      const resultMsg = ctx.sent.find(
+        (s) => typeof s.content === 'string' && s.content === '続きの結果',
+      );
+      expect(resultMsg).toBeDefined();
     });
   });
 
@@ -469,13 +473,11 @@ describe('統合テスト', () => {
       simulateClose(proc, 0);
       await waitForUsage();
 
-      // Embed 送信時に content にメンションが含まれる
-      const embedSent = ctx.sent.find((s) => {
-        if (typeof s.content === 'string') return false;
-        const opts = s.content as SendOptions;
-        return opts.content === '<@user-1>';
-      });
-      expect(embedSent).toBeDefined();
+      // テキスト送信時にメンションが含まれる
+      const mentionSent = ctx.sent.find(
+        (s) => typeof s.content === 'string' && (s.content as string).startsWith('<@user-1>'),
+      );
+      expect(mentionSent).toBeDefined();
     });
   });
 
@@ -498,13 +500,11 @@ describe('統合テスト', () => {
       await waitForUsage();
 
       expect(ctx.orchestrator.state).toBe('idle');
-      // result Embed は送信される
-      const embedSent = ctx.sent.find((s) => {
-        if (typeof s.content === 'string') return false;
-        const opts = s.content as SendOptions;
-        return opts.embeds?.[0]?.description === '結果です';
-      });
-      expect(embedSent).toBeDefined();
+      // result はプレーンテキストで送信される
+      const resultMsg = ctx.sent.find(
+        (s) => typeof s.content === 'string' && (s.content as string).includes('結果です'),
+      );
+      expect(resultMsg).toBeDefined();
     });
   });
 });

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -154,7 +154,7 @@ function getEmbeds(sent: SentItem[]): SendOptions[] {
 
 describe('統合テスト: コンポーネント配線', () => {
   describe('メッセージ → ClaudeCode → 結果通知', () => {
-    it('スレッド内のメッセージが ClaudeCode に送信され、結果が Embed で通知される', () => {
+    it('スレッド内のメッセージが ClaudeCode に送信され、結果がテキストで通知される', () => {
       const ctx = createIntegrationContext();
 
       ctx.handleMessage(validMessage('テストを書いて'));
@@ -170,11 +170,9 @@ describe('統合テスト: コンポーネント配線', () => {
       sendStdout(proc, JSON.stringify({ type: 'result', result: '完了しました' }));
       simulateClose(proc, 0);
 
-      // result は usage 到着後に Embed で送信される
-      const embeds = getEmbeds(ctx.sent);
-      expect(embeds).toHaveLength(1);
-      expect(embeds[0].embeds[0].description).toBe('完了しました');
-      expect(embeds[0].embeds[0].color).toBe(0x00c853);
+      // result は usage 到着後にプレーンテキストで送信される
+      const textMessages = getTextMessages(ctx.sent);
+      expect(textMessages).toContain('完了しました');
     });
 
     it('連続したメッセージが同一セッションで処理される', () => {
@@ -202,15 +200,14 @@ describe('統合テスト: コンポーネント配線', () => {
       sendStdout(proc2, JSON.stringify({ type: 'result', result: '結果2' }));
       simulateClose(proc2, 0);
 
-      const embeds = getEmbeds(ctx.sent);
-      expect(embeds).toHaveLength(2);
-      expect(embeds[0].embeds[0].description).toBe('結果1');
-      expect(embeds[1].embeds[0].description).toBe('結果2');
+      const textMessages = getTextMessages(ctx.sent);
+      expect(textMessages).toContain('結果1');
+      expect(textMessages).toContain('結果2');
     });
   });
 
   describe('途中経過のリアルタイム通知', () => {
-    it('ツール使用イベントがプレーンテキストで通知される', async () => {
+    it('ツール使用イベントが Embed で通知される', async () => {
       const ctx = createIntegrationContext();
 
       ctx.handleMessage(validMessage('ファイルを編集して'));
@@ -237,11 +234,13 @@ describe('統合テスト: コンポーネント配線', () => {
         }),
       );
 
-      const textMessages = getTextMessages(ctx.sent);
-      expect(textMessages).toContain('🔧 Edit: src/index.ts');
+      const embeds = getEmbeds(ctx.sent);
+      const toolEmbed = embeds.find((e) => e.embeds[0].description?.includes('Edit'));
+      expect(toolEmbed).toBeDefined();
+      expect(toolEmbed!.embeds[0].description).toContain('src/index.ts');
     });
 
-    it('拡張思考イベントがプレーンテキストで通知される', async () => {
+    it('拡張思考イベントが Embed で通知される', async () => {
       const ctx = createIntegrationContext();
 
       ctx.handleMessage(validMessage('分析して'));
@@ -261,8 +260,9 @@ describe('統合テスト: コンポーネント配線', () => {
         }),
       );
 
-      const textMessages = getTextMessages(ctx.sent);
-      expect(textMessages).toContain('💭 コードを分析中...');
+      const embeds = getEmbeds(ctx.sent);
+      const thinkingEmbed = embeds.find((e) => e.embeds[0].description?.includes('コードを分析中'));
+      expect(thinkingEmbed).toBeDefined();
     });
   });
 
@@ -353,10 +353,11 @@ describe('統合テスト: コンポーネント配線', () => {
       simulateClose(proc, 1);
 
       // error は usage 到着後に Embed で送信される
+      // progress の started embed も含まれるので、エラー embed を探す
       const embeds = getEmbeds(ctx.sent);
-      expect(embeds).toHaveLength(1);
-      expect(embeds[0].embeds[0].color).toBe(0xff1744);
-      expect(embeds[0].embeds[0].title).toContain('エラー');
+      const errorEmbed = embeds.find((e) => e.embeds[0].color === 0xff1744);
+      expect(errorEmbed).toBeDefined();
+      expect(errorEmbed!.embeds[0].title).toContain('エラー');
     });
   });
 

--- a/server/src/infrastructure/discord-notifier.test.ts
+++ b/server/src/infrastructure/discord-notifier.test.ts
@@ -49,18 +49,19 @@ describe('createNotifier', () => {
   // ----- progress 通知 -----
 
   describe('progress 通知', () => {
-    it('started イベントをプレーンテキストで送信する', () => {
+    it('started イベントを Embed で送信する', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
       notify({ type: 'progress', event: { kind: 'started' } });
 
       expect(sent).toHaveLength(1);
-      expect(sent[0].type).toBe('text');
-      expect(sent[0].content).toBe('📨 受信しました。処理を開始します...');
+      expect(sent[0].type).toBe('embed');
+      const options = sent[0].content as SendOptions;
+      expect(options.embeds[0].description).toBe('📨 受信しました。処理を開始します...');
     });
 
-    it('ツール使用イベントをプレーンテキストで送信する', () => {
+    it('ツール使用イベントを Embed で送信する', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
@@ -70,20 +71,22 @@ describe('createNotifier', () => {
       });
 
       expect(sent).toHaveLength(1);
-      expect(sent[0].type).toBe('text');
-      expect(sent[0].content).toContain('Edit');
-      expect(sent[0].content).toContain('src/index.ts');
+      expect(sent[0].type).toBe('embed');
+      const options = sent[0].content as SendOptions;
+      expect(options.embeds[0].description).toContain('Edit');
+      expect(options.embeds[0].description).toContain('src/index.ts');
     });
 
-    it('拡張思考イベントをプレーンテキストで送信する', () => {
+    it('拡張思考イベントを Embed で送信する', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
       notify({ type: 'progress', event: { kind: 'thinking', text: 'コードを分析中...' } });
 
       expect(sent).toHaveLength(1);
-      expect(sent[0].type).toBe('text');
-      expect(sent[0].content).toBe('💭 コードを分析中...');
+      expect(sent[0].type).toBe('embed');
+      const options = sent[0].content as SendOptions;
+      expect(options.embeds[0].description).toBe('💭 コードを分析中...');
     });
   });
 
@@ -114,7 +117,7 @@ describe('createNotifier', () => {
       expect(sent).toHaveLength(0); // まだ送信されない
     });
 
-    it('usage 到着時に result を緑色 Embed で送信する', () => {
+    it('usage 到着時に result をプレーンテキストで送信する', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
@@ -122,34 +125,35 @@ describe('createNotifier', () => {
       notify({ type: 'usage', usage: usageEmpty });
 
       expect(sent).toHaveLength(1);
-      expect(sent[0].type).toBe('embed');
-      const options = sent[0].content as SendOptions;
-      expect(options.embeds[0].color).toBe(0x00c853);
-      expect(options.embeds[0].description).toBe('テストを追加しました');
+      expect(sent[0].type).toBe('text');
+      expect(sent[0].content).toBe('テストを追加しました');
     });
 
-    it('usage データがある場合はフッターに含まれる', () => {
+    it('usage データがある場合はフッターがテキストで送信される', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
       notify({ type: 'result', text: '完了' });
       notify({ type: 'usage', usage: usageWithData });
 
-      expect(sent).toHaveLength(1);
-      const options = sent[0].content as SendOptions;
-      expect(options.embeds[0].footer?.text).toBe('📊 5h 45% | 7d 30%');
+      expect(sent).toHaveLength(2);
+      expect(sent[0].type).toBe('text');
+      expect(sent[0].content).toBe('完了');
+      expect(sent[1].type).toBe('text');
+      expect(sent[1].content).toBe('📊 5h 45% | 7d 30%');
     });
 
-    it('Sonnet 利用状況がフッターに含まれる', () => {
+    it('Sonnet 利用状況がフッターがテキストで送信される', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
       notify({ type: 'result', text: '完了' });
       notify({ type: 'usage', usage: usageWithSonnet });
 
-      expect(sent).toHaveLength(1);
-      const options = sent[0].content as SendOptions;
-      expect(options.embeds[0].footer?.text).toBe('📊 5h 45% | Sonnet 80%');
+      expect(sent).toHaveLength(2);
+      expect(sent[0].type).toBe('text');
+      expect(sent[1].type).toBe('text');
+      expect(sent[1].content).toBe('📊 5h 45% | Sonnet 80%');
     });
 
     it('usage データがない場合はフッターなし', () => {
@@ -159,11 +163,12 @@ describe('createNotifier', () => {
       notify({ type: 'result', text: '完了' });
       notify({ type: 'usage', usage: usageEmpty });
 
-      const options = sent[0].content as SendOptions;
-      expect(options.embeds[0].footer).toBeUndefined();
+      expect(sent).toHaveLength(1);
+      expect(sent[0].type).toBe('text');
+      expect(sent[0].content).toBe('完了');
     });
 
-    it('4096 文字超の result（usage データなし）はプレーンテキスト分割 + 空 Embed', () => {
+    it('長文 result はプレーンテキスト分割で送信する', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
@@ -171,15 +176,14 @@ describe('createNotifier', () => {
       notify({ type: 'result', text: longText });
       notify({ type: 'usage', usage: usageEmpty });
 
-      expect(sent).toHaveLength(4);
+      // 5000文字 → 2000 + 2000 + 1000 のプレーンテキスト
+      expect(sent).toHaveLength(3);
       expect(sent[0].type).toBe('text');
-      expect(sent[3].type).toBe('embed');
-      const options = sent[3].content as SendOptions;
-      expect(options.embeds[0].color).toBe(0x00c853);
-      expect(options.embeds[0].footer).toBeUndefined();
+      expect(sent[1].type).toBe('text');
+      expect(sent[2].type).toBe('text');
     });
 
-    it('4096 文字超の result はプレーンテキスト分割 + フッター Embed', () => {
+    it('長文 result はプレーンテキスト分割 + フッターテキストで送信する', () => {
       const { thread, sent } = createMockThread();
       const { notify } = createNotifier(thread);
 
@@ -187,16 +191,13 @@ describe('createNotifier', () => {
       notify({ type: 'result', text: longText });
       notify({ type: 'usage', usage: usageWithData });
 
-      // 5000文字 → 2000 + 2000 + 1000 のプレーンテキスト + 1 Embed
+      // 5000文字 → 2000 + 2000 + 1000 のプレーンテキスト + 1 フッターテキスト
       expect(sent).toHaveLength(4);
       expect(sent[0].type).toBe('text');
       expect(sent[1].type).toBe('text');
       expect(sent[2].type).toBe('text');
-      expect(sent[3].type).toBe('embed');
-      const options = sent[3].content as SendOptions;
-      expect(options.embeds[0].color).toBe(0x00c853);
-      expect(options.embeds[0].footer?.text).toBe('📊 5h 45% | 7d 30%');
-      expect(options.embeds[0].description).toBeUndefined();
+      expect(sent[3].type).toBe('text');
+      expect(sent[3].content).toBe('📊 5h 45% | 7d 30%');
     });
   });
 
@@ -276,14 +277,13 @@ describe('createNotifier', () => {
       notify({ type: 'result', text: '完了しました' });
       notify({ type: 'usage', usage: usageWithData });
 
-      expect(sent).toHaveLength(3); // 2 progress + 1 embed
-      expect(sent[0].type).toBe('text');
-      expect(sent[1].type).toBe('text');
-      expect(sent[2].type).toBe('embed');
-      const options = sent[2].content as SendOptions;
-      expect(options.embeds[0].color).toBe(0x00c853);
-      expect(options.embeds[0].description).toBe('完了しました');
-      expect(options.embeds[0].footer?.text).toBe('📊 5h 45% | 7d 30%');
+      expect(sent).toHaveLength(4); // 2 progress embed + 1 result text + 1 footer text
+      expect(sent[0].type).toBe('embed');
+      expect(sent[1].type).toBe('embed');
+      expect(sent[2].type).toBe('text');
+      expect(sent[2].content).toBe('完了しました');
+      expect(sent[3].type).toBe('text');
+      expect(sent[3].content).toBe('📊 5h 45% | 7d 30%');
     });
 
     it('progress → error → usage の完全フロー', () => {
@@ -294,8 +294,8 @@ describe('createNotifier', () => {
       notify({ type: 'error', message: 'command failed', exitCode: 1 });
       notify({ type: 'usage', usage: usageWithData });
 
-      expect(sent).toHaveLength(2); // 1 progress + 1 embed
-      expect(sent[0].type).toBe('text');
+      expect(sent).toHaveLength(2); // 1 progress embed + 1 error embed
+      expect(sent[0].type).toBe('embed');
       expect(sent[1].type).toBe('embed');
       const options = sent[1].content as SendOptions;
       expect(options.embeds[0].color).toBe(0xff1744);
@@ -334,11 +334,12 @@ describe('createNotifier', () => {
       notifier.notify({ type: 'progress', event: { kind: 'thinking', text: '考え中' } });
 
       for (const item of sent) {
-        expect(item.content).not.toContain('<@user123>');
+        const options = item.content as SendOptions;
+        expect(options.content).toBeUndefined();
       }
     });
 
-    it('result の Embed 送信時に content でメンションが付く', () => {
+    it('result のテキスト送信時にメンションが付く', () => {
       const { thread, sent } = createMockThread();
       const notifier = createNotifier(thread);
       notifier.setAuthorId('user456');
@@ -347,9 +348,8 @@ describe('createNotifier', () => {
       notifier.notify({ type: 'usage', usage: usageEmpty });
 
       expect(sent).toHaveLength(1);
-      const options = sent[0].content as SendOptions;
-      expect(options.content).toBe('<@user456>');
-      expect(options.embeds[0].description).toBe('完了');
+      expect(sent[0].type).toBe('text');
+      expect(sent[0].content).toBe('<@user456> 完了');
     });
 
     it('error の Embed 送信時に content でメンションが付く', () => {

--- a/server/src/infrastructure/discord-notifier.ts
+++ b/server/src/infrastructure/discord-notifier.ts
@@ -48,7 +48,7 @@ function formatUsageFooter(usage: UsageInfo): string | null {
 
 const COLOR_SUCCESS = 0x00c853;
 const COLOR_ERROR = 0xff1744;
-const EMBED_MAX_LENGTH = 4096;
+const COLOR_PROGRESS = 0x78909c;
 
 type PendingResult =
   | { type: 'result'; text: string }
@@ -63,9 +63,11 @@ export interface Notifier {
  * セッションスレッド用の Notifier を作成する。
  *
  * 通知の流れ:
- * - progress / info → プレーンテキストとして即座に送信
- * - result / error → バッファ（usage を待つ）
- * - usage → バッファされた result/error と結合して Embed で送信
+ * - progress → Embed として即座に送信
+ * - info → プレーンテキストとして即座に送信
+ * - result → バッファ → usage 到着時にプレーンテキストで送信
+ * - error → バッファ → usage 到着時に Embed で送信
+ * - usage → バッファされた result/error と結合して送信
  *
  * setAuthorId で質問者を設定すると、started / result / error 送信時にメンションを付与する。
  */
@@ -101,26 +103,17 @@ export function createNotifier(thread: ThreadSender): Notifier {
     }
 
     if (result.type === 'result') {
-      if (result.text.length <= EMBED_MAX_LENGTH) {
-        const embed: EmbedData = {
-          color: COLOR_SUCCESS,
-          description: result.text,
-        };
-        if (footer) embed.footer = { text: footer };
-        sendEmbed(embed, true);
-      } else {
-        const chunks = splitMessage(result.text);
-        const m = mention();
-        for (let i = 0; i < chunks.length; i++) {
-          if (i === 0 && m) {
-            sendText(`${m} ${chunks[i]}`);
-          } else {
-            sendText(chunks[i]);
-          }
+      const m = mention();
+      const chunks = splitMessage(result.text);
+      for (let i = 0; i < chunks.length; i++) {
+        if (i === 0 && m) {
+          sendText(`${m} ${chunks[i]}`);
+        } else {
+          sendText(chunks[i]);
         }
-        const embed: EmbedData = { color: COLOR_SUCCESS };
-        if (footer) embed.footer = { text: footer };
-        sendEmbed(embed);
+      }
+      if (footer) {
+        sendText(footer);
       }
     } else {
       const embed: EmbedData = {
@@ -136,7 +129,7 @@ export function createNotifier(thread: ThreadSender): Notifier {
   const notify: NotifyFn = (notification: Notification) => {
     switch (notification.type) {
       case 'progress':
-        sendText(formatProgress(notification));
+        sendEmbed({ color: COLOR_PROGRESS, description: formatProgress(notification) });
         break;
       case 'info':
         sendText(notification.message);


### PR DESCRIPTION
## Summary
- 考え中(progress)メッセージをプレーンテキストからDiscord Embedに変更（左バー色: `#78909c`）
- 回答(result)メッセージをEmbedからプレーンテキストに変更
- エラー通知はEmbed表示のまま維持

## Test plan
- [x] discord-notifier.test.ts: 26テスト全通過
- [x] index.test.ts: 11テスト全通過
- [x] integration.test.ts: 12テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)