### PR TITLE
refactor: 巻き戻し機能の仕様変更（ユーザー質問リプライで上書き）

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -223,11 +223,18 @@ async function main(): Promise<void> {
     // リプライ検出（巻き戻し）
     if (msg.reference?.messageId && ctx?.session.sessionId) {
       const referencedId = msg.reference.messageId;
-      const turn = await turnStore.findTurn(
-        ctx.session.sessionId,
-        ctx.session.workDir,
-        referencedId,
-      );
+
+      // 現セッション → 全セッション横断の順で検索
+      let sourceSessionId = ctx.session.sessionId;
+      let turn = await turnStore.findTurn(sourceSessionId, ctx.session.workDir, referencedId);
+
+      if (turn === null) {
+        const found = await turnStore.findTurnAcrossSessions(ctx.session.workDir, referencedId);
+        if (found) {
+          sourceSessionId = found.sessionId;
+          turn = found.turn;
+        }
+      }
 
       if (turn !== null) {
         // busy/interrupting 時は branch せず通知のみ（Orchestrator 側で処理）
@@ -243,12 +250,12 @@ async function main(): Promise<void> {
 
         try {
           const newSessionId = await sessionBrancher.branch(
-            ctx.session.sessionId,
+            sourceSessionId,
             ctx.session.workDir,
             turn,
           );
           log(
-            `巻き戻し: Turn ${turn} → 新セッション ${newSessionId.slice(0, 8)} (thread: ${msg.channelId})`,
+            `巻き戻し: Turn ${turn} (元セッション: ${sourceSessionId.slice(0, 8)}) → 新セッション ${newSessionId.slice(0, 8)} (thread: ${msg.channelId})`,
           );
 
           ctx.orchestrator.handleCommand({

--- a/server/src/infrastructure/turn-store.test.ts
+++ b/server/src/infrastructure/turn-store.test.ts
@@ -75,6 +75,36 @@ describe('TurnStore', () => {
     });
   });
 
+  describe('findTurnAcrossSessions', () => {
+    it('他セッションの turns.json からメッセージ ID を逆引きできる', async () => {
+      const store = new TurnStore();
+      await store.record('session-A', '/work', 1, 'msg-A1');
+      await store.record('session-A', '/work', 2, 'msg-A2');
+      await store.record('session-B', '/work', 1, 'msg-B1');
+
+      const result = await store.findTurnAcrossSessions('/work', 'msg-A2');
+
+      expect(result).toEqual({ sessionId: 'session-A', turn: 2 });
+    });
+
+    it('どのセッションにも存在しない ID は null を返す', async () => {
+      const store = new TurnStore();
+      await store.record('session-A', '/work', 1, 'msg-A1');
+
+      const result = await store.findTurnAcrossSessions('/work', 'msg-999');
+
+      expect(result).toBeNull();
+    });
+
+    it('turns.json がゼロ件の場合は null を返す', async () => {
+      const store = new TurnStore();
+
+      const result = await store.findTurnAcrossSessions('/work', 'msg-111');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('maxTurn', () => {
     it('最大ターン番号を返す', async () => {
       const store = new TurnStore();

--- a/server/src/infrastructure/turn-store.ts
+++ b/server/src/infrastructure/turn-store.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { projectDir } from './session-store.js';
 
@@ -58,6 +58,34 @@ export class TurnStore {
       }
     }
     await writeFile(turnsFilePath(targetSessionId, workDir), JSON.stringify(targetMap, null, 2));
+  }
+
+  /**
+   * 全セッションの turns.json を横断して Discord メッセージ ID から逆引きする。
+   * 現セッションの findTurn で見つからなかった場合のフォールバック用。
+   */
+  async findTurnAcrossSessions(
+    workDir: string,
+    discordMessageId: string,
+  ): Promise<{ sessionId: string; turn: number } | null> {
+    const dir = projectDir(workDir);
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return null;
+    }
+    const turnsFiles = entries.filter((e) => e.endsWith('.turns.json'));
+    for (const file of turnsFiles) {
+      const map = await this.load(join(dir, file));
+      for (const [turnStr, msgId] of Object.entries(map)) {
+        if (msgId === discordMessageId) {
+          const sessionId = file.replace('.turns.json', '');
+          return { sessionId, turn: Number(turnStr) };
+        }
+      }
+    }
+    return null;
   }
 
   /** セッションの最大ターン番号を返す（データがなければ 0） */


### PR DESCRIPTION
## Summary
- 巻き戻し後にセッションIDが変わるため、旧セッションの巻き戻し地点以降のBotメッセージにリプライしても巻き戻しがトリガーされなかった問題を修正
- `TurnStore.findTurnAcrossSessions()` を追加し、現セッションで見つからない場合に全セッションの `turns.json` を横断検索するフォールバック処理を実装
- 見つかった元セッションのJSONLからブランチすることで、旧タイムラインの任意の地点への巻き戻しを可能にした

## Test plan
- [ ] `findTurnAcrossSessions` のユニットテスト（他セッション逆引き・存在しないID・空ディレクトリ）
- [ ] 既存テスト全通過（804テスト）
- [ ] 手動: 巻き戻し後に旧セッションのBotメッセージにリプライして巻き戻しが発生すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)