### PR TITLE
refactor: 巻き戻し機能の仕様変更（ユーザー質問リプライで上書き）

### DIFF
--- a/server/src/__tests__/integration.test.ts
+++ b/server/src/__tests__/integration.test.ts
@@ -55,7 +55,7 @@ function createIntegrationContext() {
   const thread: ThreadSender = {
     send: vi.fn((content) => {
       sent.push({ content });
-      return Promise.resolve({ id: '' });
+      return Promise.resolve();
     }),
     sendTyping: vi.fn(() => Promise.resolve()),
     setName: vi.fn(() => Promise.resolve()),

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -52,7 +52,7 @@ function createIntegrationContext() {
     send: vi.fn((content: string | SendOptions) => {
       const type = typeof content === 'string' ? 'text' : 'embed';
       sent.push({ type, content });
-      return Promise.resolve({ id: '' });
+      return Promise.resolve();
     }),
     sendTyping: vi.fn(() => Promise.resolve()),
     setName: vi.fn(() => Promise.resolve()),
@@ -371,7 +371,7 @@ describe('統合テスト: コンポーネント配線', () => {
       const mockThread2: ThreadSender = {
         send: vi.fn((content: string | SendOptions) => {
           sent2.push({ type: typeof content === 'string' ? 'text' : 'embed', content });
-          return Promise.resolve({ id: '' });
+          return Promise.resolve();
         }),
         sendTyping: vi.fn(() => Promise.resolve()),
         setName: vi.fn(() => Promise.resolve()),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -112,14 +112,6 @@ async function main(): Promise<void> {
 
     const orchestrator = new Orchestrator(session, claudeProcess, notify, usageFetcher);
 
-    // ターン記録コールバックを設定
-    notifier.onResultSent = async (discordMessageId) => {
-      const sid = session.sessionId;
-      if (sid) {
-        await turnStore.record(sid, workspace.path, orchestrator.currentTurn, discordMessageId);
-      }
-    };
-
     onProgress = (event) => orchestrator.onProgress(event);
     onProcessEnd = (exitCode, output) => {
       log(`ClaudeProcess 終了 (exitCode: ${exitCode}, thread: ${threadId})`);
@@ -220,7 +212,7 @@ async function main(): Promise<void> {
       ctx.setAuthorId(msg.author.id);
     }
 
-    // リプライ検出（巻き戻し）
+    // リプライ検出（質問上書きによる巻き戻し）
     if (msg.reference?.messageId && ctx?.session.sessionId) {
       const referencedId = msg.reference.messageId;
 
@@ -237,11 +229,14 @@ async function main(): Promise<void> {
       }
 
       if (turn !== null) {
+        // リプライ先の質問の直前まで保持し、新しいプロンプトで上書き
+        const branchTurn = turn - 1;
+
         // busy/interrupting 時は branch せず通知のみ（Orchestrator 側で処理）
         if (ctx.orchestrator.state !== 'idle') {
           ctx.orchestrator.handleCommand({
             type: 'rewind',
-            targetTurn: turn,
+            targetTurn: branchTurn,
             newSessionId: '', // busy 時は Orchestrator が拒否するため使われない
             prompt,
           });
@@ -252,15 +247,15 @@ async function main(): Promise<void> {
           const newSessionId = await sessionBrancher.branch(
             sourceSessionId,
             ctx.session.workDir,
-            turn,
+            branchTurn,
           );
           log(
-            `巻き戻し: Turn ${turn} (元セッション: ${sourceSessionId.slice(0, 8)}) → 新セッション ${newSessionId.slice(0, 8)} (thread: ${msg.channelId})`,
+            `巻き戻し: Turn ${turn} を上書き (元セッション: ${sourceSessionId.slice(0, 8)}) → 新セッション ${newSessionId.slice(0, 8)} (thread: ${msg.channelId})`,
           );
 
           ctx.orchestrator.handleCommand({
             type: 'rewind',
-            targetTurn: turn,
+            targetTurn: branchTurn,
             newSessionId,
             prompt,
           });
@@ -287,6 +282,13 @@ async function main(): Promise<void> {
       threadId: msg.channelId,
       content: prompt,
     });
+
+    // ユーザーのメッセージ ID を記録（巻き戻し用）
+    if (ctx && prevState === 'idle' && ctx.orchestrator.state === 'busy') {
+      turnStore
+        .record(ctx.session.sessionId!, ctx.session.workDir, ctx.orchestrator.currentTurn, msg.id)
+        .catch((err) => console.error('Turn record error:', err));
+    }
 
     const newState = ctx?.orchestrator.state;
     if (prevState !== newState) {

--- a/server/src/infrastructure/discord-notifier.test.ts
+++ b/server/src/infrastructure/discord-notifier.test.ts
@@ -10,16 +10,13 @@ interface SentItem {
   content: string | SendOptions;
 }
 
-let msgIdCounter = 0;
-
 function createMockThread() {
-  msgIdCounter = 0;
   const sent: SentItem[] = [];
   const thread: ThreadSender = {
     send: vi.fn((content: string | SendOptions) => {
       const type = typeof content === 'string' ? 'text' : 'embed';
       sent.push({ type, content });
-      return Promise.resolve({ id: `msg-${++msgIdCounter}` });
+      return Promise.resolve();
     }),
     sendTyping: vi.fn(() => Promise.resolve()),
     setName: vi.fn(() => Promise.resolve()),
@@ -565,7 +562,7 @@ describe('createNotifier', () => {
     it('sendTyping のエラーは catch され console.error に出力される', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const thread: ThreadSender = {
-        send: vi.fn(() => Promise.resolve({ id: '' })),
+        send: vi.fn(() => Promise.resolve()),
         sendTyping: vi.fn(() => Promise.reject(new Error('typing error'))),
         setName: vi.fn(() => Promise.resolve()),
       };
@@ -579,87 +576,12 @@ describe('createNotifier', () => {
     });
   });
 
-  // ----- onResultSent コールバック -----
-
-  describe('onResultSent コールバック', () => {
-    it('result 送信時に onResultSent コールバックが呼ばれる', async () => {
-      const { thread } = createMockThread();
-      const notifier = createNotifier(thread);
-      const callback = vi.fn();
-      notifier.onResultSent = callback;
-
-      notifier.notify({ type: 'result', text: '完了' });
-      notifier.notify({ type: 'usage', usage: usageEmpty });
-
-      // コールバックは非同期で呼ばれるため待機
-      await vi.waitFor(() => {
-        expect(callback).toHaveBeenCalledWith('msg-1');
-      });
-    });
-
-    it('onResultSent が null の場合でもエラーにならない', () => {
-      const { thread } = createMockThread();
-      const notifier = createNotifier(thread);
-      notifier.onResultSent = null;
-
-      notifier.notify({ type: 'result', text: '完了' });
-      expect(() => notifier.notify({ type: 'usage', usage: usageEmpty })).not.toThrow();
-    });
-
-    it('長文分割時は最初のメッセージの ID のみ通知される', async () => {
-      const { thread } = createMockThread();
-      const notifier = createNotifier(thread);
-      const callback = vi.fn();
-      notifier.onResultSent = callback;
-
-      const longText = 'A'.repeat(5000);
-      notifier.notify({ type: 'result', text: longText });
-      notifier.notify({ type: 'usage', usage: usageEmpty });
-
-      await vi.waitFor(() => {
-        expect(callback).toHaveBeenCalledTimes(1);
-      });
-      expect(callback).toHaveBeenCalledWith('msg-1');
-    });
-
-    it('非同期コールバック（Promise を返す）が正しく await される', async () => {
-      const { thread } = createMockThread();
-      const notifier = createNotifier(thread);
-      const order: string[] = [];
-      notifier.onResultSent = async (msgId) => {
-        await new Promise((r) => setTimeout(r, 10));
-        order.push(`recorded:${msgId}`);
-      };
-
-      notifier.notify({ type: 'result', text: '完了' });
-      notifier.notify({ type: 'usage', usage: usageEmpty });
-
-      await vi.waitFor(() => {
-        expect(order).toEqual(['recorded:msg-1']);
-      });
-    });
-
-    it('error 送信時は onResultSent が呼ばれない', async () => {
-      const { thread } = createMockThread();
-      const notifier = createNotifier(thread);
-      const callback = vi.fn();
-      notifier.onResultSent = callback;
-
-      notifier.notify({ type: 'error', message: 'failed', exitCode: 1 });
-      notifier.notify({ type: 'usage', usage: usageEmpty });
-
-      // 少し待ってコールバックが呼ばれていないことを確認
-      await new Promise((r) => setTimeout(r, 50));
-      expect(callback).not.toHaveBeenCalled();
-    });
-  });
-
   // ----- 送信エラー -----
 
   describe('送信エラー', () => {
     it('テキスト send が失敗してもエラーを投げない', () => {
       const thread: ThreadSender = {
-        send: vi.fn(() => Promise.reject(new Error('network error'))) as ThreadSender['send'],
+        send: vi.fn(() => Promise.reject(new Error('network error'))),
         sendTyping: vi.fn(() => Promise.resolve()),
         setName: vi.fn(() => Promise.resolve()),
       };
@@ -670,7 +592,7 @@ describe('createNotifier', () => {
 
     it('embed send が失敗してもエラーを投げない', () => {
       const thread: ThreadSender = {
-        send: vi.fn(() => Promise.reject(new Error('network error'))) as ThreadSender['send'],
+        send: vi.fn(() => Promise.reject(new Error('network error'))),
         sendTyping: vi.fn(() => Promise.resolve()),
         setName: vi.fn(() => Promise.resolve()),
       };
@@ -682,7 +604,7 @@ describe('createNotifier', () => {
 
     it('progress の embed send が失敗してもエラーを投げない', () => {
       const thread: ThreadSender = {
-        send: vi.fn(() => Promise.reject(new Error('network error'))) as ThreadSender['send'],
+        send: vi.fn(() => Promise.reject(new Error('network error'))),
         sendTyping: vi.fn(() => Promise.resolve()),
         setName: vi.fn(() => Promise.resolve()),
       };

--- a/server/src/infrastructure/discord-notifier.ts
+++ b/server/src/infrastructure/discord-notifier.ts
@@ -13,7 +13,7 @@ export interface SendOptions {
 }
 
 export interface ThreadSender {
-  send(content: string | SendOptions): Promise<{ id: string }>;
+  send(content: string | SendOptions): Promise<unknown>;
   sendTyping(): Promise<unknown>;
   setName(name: string): Promise<unknown>;
 }
@@ -59,7 +59,6 @@ type PendingResult =
 export interface Notifier {
   notify: NotifyFn;
   setAuthorId(authorId: string): void;
-  onResultSent: ((discordMessageId: string) => void | Promise<void>) | null;
   dispose(): void;
 }
 
@@ -80,7 +79,6 @@ export function createNotifier(thread: ThreadSender): Notifier {
   let currentAuthorId: string | null = null;
   let typingInterval: NodeJS.Timeout | null = null;
   let isTyping = false;
-  let resultSentCallback: ((discordMessageId: string) => void | Promise<void>) | null = null;
 
   function mention(): string | null {
     return currentAuthorId ? `<@${currentAuthorId}>` : null;
@@ -105,16 +103,12 @@ export function createNotifier(thread: ThreadSender): Notifier {
     }
   }
 
-  function sendText(text: string): Promise<{ id: string }> {
-    return thread.send(text).then(
-      (msg) => {
+  function sendText(text: string): void {
+    thread.send(text).then(
+      () => {
         if (isTyping) fireTyping();
-        return msg;
       },
-      (err) => {
-        console.error('Discord send error:', err);
-        return { id: '' };
-      },
+      (err) => console.error('Discord send error:', err),
     );
   }
 
@@ -151,14 +145,7 @@ export function createNotifier(thread: ThreadSender): Notifier {
       const chunks = rest.length > 0 ? [firstChunk, ...splitMessage(rest, 2000)] : [firstChunk];
       for (let i = 0; i < chunks.length; i++) {
         const text = i === 0 && mentionPrefix ? `${mentionPrefix}${chunks[i]}` : chunks[i];
-        const p = sendText(text);
-        // 最初のメッセージの ID をコールバックで通知（非同期コールバック対応）
-        if (i === 0 && resultSentCallback) {
-          const cb = resultSentCallback;
-          p.then(async (msg) => {
-            if (msg.id) await cb(msg.id);
-          }).catch((err) => console.error('onResultSent callback error:', err));
-        }
+        sendText(text);
       }
       if (footer) {
         sendText(footer);
@@ -200,20 +187,13 @@ export function createNotifier(thread: ThreadSender): Notifier {
     }
   };
 
-  const notifier: Notifier = {
+  return {
     notify,
     setAuthorId(authorId: string) {
       currentAuthorId = authorId;
-    },
-    get onResultSent() {
-      return resultSentCallback;
-    },
-    set onResultSent(cb: ((discordMessageId: string) => void | Promise<void>) | null) {
-      resultSentCallback = cb;
     },
     dispose() {
       stopTyping();
     },
   };
-  return notifier;
 }

--- a/server/src/infrastructure/session-brancher.test.ts
+++ b/server/src/infrastructure/session-brancher.test.ts
@@ -151,6 +151,39 @@ describe('SessionBrancher', () => {
     expect(turn3).toBeNull();
   });
 
+  it('targetTurn が 0 の場合はメタデータ行のみの空セッションが作成される', async () => {
+    const turnStore = new TurnStore();
+    const brancher = new SessionBrancher(turnStore);
+
+    const lines = [
+      metadataLine(),
+      userLine('質問1'),
+      assistantLine('回答1'),
+    ];
+    await writeFile(join(projDir, 'original.jsonl'), lines.join('\n'));
+
+    const newId = await brancher.branch('original', '/work', 0);
+
+    const newContent = await readFile(join(projDir, `${newId}.jsonl`), 'utf-8');
+    const newLines = newContent.trim().split('\n').filter((l) => l.trim() !== '');
+    // メタデータ行のみ
+    expect(newLines).toHaveLength(1);
+    expect(JSON.parse(newLines[0]).type).toBe('file-history-snapshot');
+  });
+
+  it('targetTurn が 0 でメタデータなしの場合は空ファイルが作成される', async () => {
+    const turnStore = new TurnStore();
+    const brancher = new SessionBrancher(turnStore);
+
+    const lines = [userLine('質問1'), assistantLine('回答1')];
+    await writeFile(join(projDir, 'original.jsonl'), lines.join('\n'));
+
+    const newId = await brancher.branch('original', '/work', 0);
+
+    const newContent = await readFile(join(projDir, `${newId}.jsonl`), 'utf-8');
+    expect(newContent).toBe('');
+  });
+
   it('targetTurn が実際のターン数を超える場合にエラーを投げる', async () => {
     const turnStore = new TurnStore();
     const brancher = new SessionBrancher(turnStore);

--- a/server/src/infrastructure/session-brancher.test.ts
+++ b/server/src/infrastructure/session-brancher.test.ts
@@ -155,17 +155,16 @@ describe('SessionBrancher', () => {
     const turnStore = new TurnStore();
     const brancher = new SessionBrancher(turnStore);
 
-    const lines = [
-      metadataLine(),
-      userLine('質問1'),
-      assistantLine('回答1'),
-    ];
+    const lines = [metadataLine(), userLine('質問1'), assistantLine('回答1')];
     await writeFile(join(projDir, 'original.jsonl'), lines.join('\n'));
 
     const newId = await brancher.branch('original', '/work', 0);
 
     const newContent = await readFile(join(projDir, `${newId}.jsonl`), 'utf-8');
-    const newLines = newContent.trim().split('\n').filter((l) => l.trim() !== '');
+    const newLines = newContent
+      .trim()
+      .split('\n')
+      .filter((l) => l.trim() !== '');
     // メタデータ行のみ
     expect(newLines).toHaveLength(1);
     expect(JSON.parse(newLines[0]).type).toBe('file-history-snapshot');

--- a/server/src/infrastructure/session-brancher.ts
+++ b/server/src/infrastructure/session-brancher.ts
@@ -22,29 +22,45 @@ export class SessionBrancher {
     let turnCount = 0;
     let cutIndex = 0;
 
-    for (let i = 0; i < lines.length; i++) {
-      try {
-        const parsed = JSON.parse(lines[i]);
-        if (parsed.type === 'assistant') {
-          turnCount++;
-          if (turnCount === targetTurn) {
-            cutIndex = i + 1;
+    if (targetTurn === 0) {
+      // Turn 0: メタデータ行（user/assistant 以外）のみ保持
+      for (let i = 0; i < lines.length; i++) {
+        try {
+          const parsed = JSON.parse(lines[i]);
+          if (parsed.type === 'user' || parsed.type === 'assistant') {
+            cutIndex = i;
             break;
           }
+        } catch {
+          // パース不能行はそのままコピー
         }
-      } catch {
-        // パース不能行はターンカウントに影響しない（そのままコピー）
       }
-    }
+      if (cutIndex === 0) cutIndex = 0; // メタデータがない場合も空で作成
+    } else {
+      for (let i = 0; i < lines.length; i++) {
+        try {
+          const parsed = JSON.parse(lines[i]);
+          if (parsed.type === 'assistant') {
+            turnCount++;
+            if (turnCount === targetTurn) {
+              cutIndex = i + 1;
+              break;
+            }
+          }
+        } catch {
+          // パース不能行はターンカウントに影響しない（そのままコピー）
+        }
+      }
 
-    if (cutIndex === 0) {
-      throw new Error(`Turn ${targetTurn} が見つかりません（全 ${turnCount} ターン）`);
+      if (cutIndex === 0) {
+        throw new Error(`Turn ${targetTurn} が見つかりません（全 ${turnCount} ターン）`);
+      }
     }
 
     const newSessionId = randomUUID();
     const newLines = lines.slice(0, cutIndex);
     const newPath = join(dir, `${newSessionId}.jsonl`);
-    await writeFile(newPath, newLines.join('\n') + '\n');
+    await writeFile(newPath, newLines.length > 0 ? newLines.join('\n') + '\n' : '');
 
     // turns.json もコピー
     await this.turnStore.copyTo(sessionId, newSessionId, workDir, targetTurn);


### PR DESCRIPTION
## Summary
- 巻き戻しのトリガーを「Bot回答へのリプライ」から「ユーザー自身の質問へのリプライ」に変更
- リプライ内容でその質問を上書きし、直前の状態から再実行する挙動に
- 旧セッションのメッセージへのリプライでも巻き戻し可能（全セッション横断検索）
- `onResultSent` コールバックを削除（Bot送信ID追跡が不要に）

## Changes
- **`turn-store.ts`**: `findTurnAcrossSessions()` を追加（全セッション横断検索）
- **`session-brancher.ts`**: `targetTurn=0` をサポート（最初の質問の上書き）
- **`index.ts`**: ユーザーメッセージID記録、ブランチ位置を `turn-1` に変更
- **`discord-notifier.ts`**: `onResultSent` コールバックを削除、`send()` 戻り値を `Promise<unknown>` に戻す
- **`orchestrator.ts`**: 空 `newSessionId` のガード追加

## Test plan
- [ ] `findTurnAcrossSessions` のユニットテスト（3テスト）
- [ ] `targetTurn=0` のユニットテスト（2テスト）
- [ ] 空 `newSessionId` ガードのテスト
- [ ] 既存テスト全通過（801テスト）
- [ ] 手動: 自分の質問にリプライして巻き戻し+上書きが発生すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)