### PR TITLE
fix: branch()のターンカウントをユーザープロンプト基準に修正

### DIFF
--- a/server/src/infrastructure/session-brancher.test.ts
+++ b/server/src/infrastructure/session-brancher.test.ts
@@ -36,6 +36,23 @@ function assistantLine(content: string): string {
   });
 }
 
+function toolUseLine(): string {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 't1', name: 'read', input: {} }],
+    },
+  });
+}
+
+function toolResultLine(): string {
+  return JSON.stringify({
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+  });
+}
+
 function metadataLine(): string {
   return JSON.stringify({ type: 'file-history-snapshot', messageId: 'test', snapshot: {} });
 }
@@ -181,6 +198,35 @@ describe('SessionBrancher', () => {
 
     const newContent = await readFile(join(projDir, `${newId}.jsonl`), 'utf-8');
     expect(newContent).toBe('');
+  });
+
+  it('ツール使用を含むターンが正しく1ターンとしてカウントされる', async () => {
+    const turnStore = new TurnStore();
+    const brancher = new SessionBrancher(turnStore);
+
+    // Turn 1: ツール使用あり（user → assistant(tool_use) → user(tool_result) → assistant(text)）
+    // Turn 2: 通常（user → assistant）
+    // Turn 3: 通常（user → assistant）
+    const lines = [
+      userLine('質問1'),
+      toolUseLine(),
+      toolResultLine(),
+      assistantLine('回答1'),
+      userLine('質問2'),
+      assistantLine('回答2'),
+      userLine('質問3'),
+      assistantLine('回答3'),
+    ];
+    await writeFile(join(projDir, 'original.jsonl'), lines.join('\n'));
+
+    const newId = await brancher.branch('original', '/work', 2);
+
+    const newContent = await readFile(join(projDir, `${newId}.jsonl`), 'utf-8');
+    const newLines = newContent.trim().split('\n');
+    // Turn 1 (4行: user, assistant(tool), user(tool_result), assistant) + Turn 2 (2行: user, assistant) = 6行
+    expect(newLines).toHaveLength(6);
+    expect(JSON.parse(newLines[4]).message.content).toBe('質問2');
+    expect(JSON.parse(newLines[5]).message.content[0].text).toBe('回答2');
   });
 
   it('targetTurn が実際のターン数を超える場合にエラーを投げる', async () => {

--- a/server/src/infrastructure/session-brancher.ts
+++ b/server/src/infrastructure/session-brancher.ts
@@ -4,11 +4,26 @@ import { join } from 'node:path';
 import { projectDir } from './session-store.js';
 import type { TurnStore } from './turn-store.js';
 
+/** ユーザープロンプト行かどうか（tool_result は除外） */
+function isUserPrompt(parsed: Record<string, unknown>): boolean {
+  if (parsed.type !== 'user') return false;
+  const msg = parsed.message as Record<string, unknown> | undefined;
+  const content = msg?.content;
+  if (Array.isArray(content)) {
+    return !content.some((c: Record<string, unknown>) => c.type === 'tool_result');
+  }
+  return true;
+}
+
 export class SessionBrancher {
   constructor(private readonly turnStore: TurnStore) {}
 
   /**
    * 指定ターンまでの会話で分岐セッションを作成する。
+   *
+   * ターンの定義: ユーザープロンプト（tool_result を除く user 行）1つで1ターン。
+   * ツール使用時に複数の assistant/user 行が生成されても1ターンとしてカウントする。
+   *
    * @returns 新しい sessionId
    */
   async branch(sessionId: string, workDir: string, targetTurn: number): Promise<string> {
@@ -18,42 +33,32 @@ export class SessionBrancher {
     const content = await readFile(sourcePath, 'utf-8');
     const lines = content.split('\n').filter((line) => line.trim() !== '');
 
-    // ターン（user/assistant ペア）をカウントしながら切り詰め位置を決定
-    let turnCount = 0;
-    let cutIndex = 0;
+    // ユーザープロンプト（tool_result 以外の user 行）をカウントして切り詰め位置を決定
+    // (N+1) 番目のユーザープロンプトの直前で切る = N ターン分を保持
+    let userPromptCount = 0;
+    let cutIndex = -1;
 
-    if (targetTurn === 0) {
-      // Turn 0: メタデータ行（user/assistant 以外）のみ保持
-      for (let i = 0; i < lines.length; i++) {
-        try {
-          const parsed = JSON.parse(lines[i]);
-          if (parsed.type === 'user' || parsed.type === 'assistant') {
+    for (let i = 0; i < lines.length; i++) {
+      try {
+        const parsed = JSON.parse(lines[i]);
+        if (isUserPrompt(parsed)) {
+          userPromptCount++;
+          if (userPromptCount === targetTurn + 1) {
             cutIndex = i;
             break;
           }
-        } catch {
-          // パース不能行はそのままコピー
         }
+      } catch {
+        // パース不能行はカウントに影響しない
       }
-      if (cutIndex === 0) cutIndex = 0; // メタデータがない場合も空で作成
-    } else {
-      for (let i = 0; i < lines.length; i++) {
-        try {
-          const parsed = JSON.parse(lines[i]);
-          if (parsed.type === 'assistant') {
-            turnCount++;
-            if (turnCount === targetTurn) {
-              cutIndex = i + 1;
-              break;
-            }
-          }
-        } catch {
-          // パース不能行はターンカウントに影響しない（そのままコピー）
-        }
-      }
+    }
 
-      if (cutIndex === 0) {
-        throw new Error(`Turn ${targetTurn} が見つかりません（全 ${turnCount} ターン）`);
+    if (cutIndex === -1) {
+      if (userPromptCount === targetTurn) {
+        // targetTurn が実ターン数と一致 → 全行を保持
+        cutIndex = lines.length;
+      } else {
+        throw new Error(`Turn ${targetTurn} が見つかりません（全 ${userPromptCount} ターン）`);
       }
     }
 


### PR DESCRIPTION
ツール使用時に1ターンで複数のassistant行がJSONLに生成されるため、
assistant行でカウントするとOrchestratorのターン数とずれていた。
ユーザープロンプト（tool_resultを除くuser行）でカウントする方式に
変更し、ツール使用の有無に関わらず正確にターンを特定できるようにした。