### PR TITLE
refactor: createSession/persistMapping を discord/session-factory.ts に分離 (#17)

### DIFF
--- a/server/src/discord/session-factory.test.ts
+++ b/server/src/discord/session-factory.test.ts
@@ -133,7 +133,7 @@ describe('createSessionFactory', () => {
     expect(() => createSession('thread-1', thread, WORKSPACE)).not.toThrow();
   });
 
-  it('setAuthorId を経由したメンション設定が後続の送信に反映される', async () => {
+  it('setAuthorId で設定したユーザーへのメンションが result 送信に付与される', async () => {
     const createSession = createSessionFactory({
       config: { claudePath: '/usr/bin/claude' },
       sessionManager,
@@ -145,22 +145,20 @@ describe('createSessionFactory', () => {
     ctx.setAuthorId('user-123');
     ctx.session.ensure();
 
-    // エラー通知を notifier 経由で送ると、mention 付きで送信される。
-    // まず result をバッファし、その後 usage でフラッシュさせる。
+    // 正常系: onProcessEnd(0, output) → orchestrator が result 通知を発火 → notifier が pendingResult にバッファ
+    // → orchestrator が usageFetcher.fetch() を経て usage 通知を発火 → notifier.flush() で mention 付きで送信
     const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
-    mockProc.onProcessEnd(1, 'エラー詳細');
+    mockProc.onProcessEnd(0, '回答本文');
 
     await flushAsync();
 
     const sendMock = vi.mocked(thread.send);
-    expect(sendMock).toHaveBeenCalled();
-    // 最後の送信が mention 付きで行われることを検証
-    const lastCall = sendMock.mock.calls[sendMock.mock.calls.length - 1][0];
-    if (typeof lastCall === 'string') {
-      expect(lastCall).toContain('<@user-123>');
-    } else {
-      expect(lastCall.content).toContain('<@user-123>');
-    }
+    // result はプレーンテキスト送信、mention は先頭に付与される (discord-notifier.ts:140-148)
+    const resultCall = sendMock.mock.calls.find(
+      ([arg]) => typeof arg === 'string' && arg.includes('<@user-123>'),
+    );
+    expect(resultCall).toBeDefined();
+    expect(resultCall?.[0]).toContain('回答本文');
   });
 
   describe('プロセス終了時のタイトル生成', () => {

--- a/server/src/discord/session-factory.test.ts
+++ b/server/src/discord/session-factory.test.ts
@@ -245,9 +245,10 @@ describe('createSessionFactory', () => {
       expect(thread.setName).not.toHaveBeenCalled();
     });
 
-    it('titleGenerator.generate が reject してもエラーを伝播させない', async () => {
+    it('titleGenerator.generate が reject した場合は console.error で記録し、伝播させない', async () => {
       const titleGenerator = createMockTitleGenerator();
-      vi.mocked(titleGenerator.generate).mockRejectedValueOnce(new Error('API error'));
+      const apiError = new Error('API error');
+      vi.mocked(titleGenerator.generate).mockRejectedValueOnce(apiError);
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const createSession = createSessionFactory({
@@ -265,12 +266,14 @@ describe('createSessionFactory', () => {
 
       await flushAsync();
       expect(thread.setName).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Title generation error:', apiError);
       consoleErrorSpy.mockRestore();
     });
 
-    it('thread.setName が reject してもエラーを伝播させない', async () => {
+    it('thread.setName が reject した場合は console.error で記録し、伝播させない', async () => {
       const titleGenerator = createMockTitleGenerator();
-      vi.mocked(thread.setName).mockRejectedValueOnce(new Error('Discord error'));
+      const discordError = new Error('Discord error');
+      vi.mocked(thread.setName).mockRejectedValueOnce(discordError);
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const createSession = createSessionFactory({
@@ -287,7 +290,8 @@ describe('createSessionFactory', () => {
       mockProc.onProcessEnd(0, 'output');
 
       await flushAsync();
-      // 例外が伝播しなければ成功
+      expect(thread.setName).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Thread setName error:', discordError);
       consoleErrorSpy.mockRestore();
     });
   });

--- a/server/src/discord/session-factory.test.ts
+++ b/server/src/discord/session-factory.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionManager } from '../domain/session-manager.js';
+import type { IUsageFetcher, ProgressEvent, Workspace } from '../domain/types.js';
+import type { ITitleGenerator } from '../infrastructure/title-generator.js';
+import type { ThreadSender } from '../infrastructure/discord-notifier.js';
+import type { ThreadMappingStore } from '../infrastructure/thread-mapping-store.js';
+import { createSessionFactory, createPersistMapping } from './session-factory.js';
+
+// ClaudeProcess を最小限のモックに差し替える。
+// constructor に渡された onProgress / onProcessEnd をインスタンスに保持することで
+// テスト側から明示的にコールバックを発火できる。
+vi.mock('../infrastructure/claude-process.js', () => {
+  class MockClaudeProcess {
+    isRunning = false;
+    spawn = vi.fn();
+    interrupt = vi.fn();
+    constructor(
+      public readonly claudePath: string,
+      public readonly onProgress: (event: ProgressEvent) => void,
+      public readonly onProcessEnd: (exitCode: number, output: string) => void,
+    ) {}
+  }
+  return { ClaudeProcess: MockClaudeProcess };
+});
+
+interface MockClaudeProcessLike {
+  claudePath: string;
+  onProgress: (event: ProgressEvent) => void;
+  onProcessEnd: (exitCode: number, output: string) => void;
+}
+
+function createMockThread(): ThreadSender {
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    sendTyping: vi.fn().mockResolvedValue(undefined),
+    setName: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockUsageFetcher(): IUsageFetcher {
+  return {
+    fetch: vi.fn().mockResolvedValue({
+      fiveHour: null,
+      sevenDay: null,
+      sevenDaySonnet: null,
+    }),
+  };
+}
+
+function createMockTitleGenerator(): ITitleGenerator {
+  return {
+    generate: vi.fn().mockResolvedValue('生成されたタイトル'),
+  };
+}
+
+/** 保留中の非同期マイクロタスク・Promise をまとめて消化する */
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    await Promise.resolve();
+    await new Promise((r) => setImmediate(r));
+  }
+}
+
+const WORKSPACE: Workspace = { name: 'my-project', path: '/home/user/project' };
+
+describe('createSessionFactory', () => {
+  let sessionManager: SessionManager;
+  let usageFetcher: IUsageFetcher;
+  let thread: ThreadSender;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionManager = new SessionManager();
+    usageFetcher = createMockUsageFetcher();
+    thread = createMockThread();
+  });
+
+  it('依存を受け取り、SessionContext を返す関数を生成する', () => {
+    const createSession = createSessionFactory({
+      config: { claudePath: '/usr/bin/claude' },
+      sessionManager,
+      usageFetcher,
+      titleGenerator: null,
+    });
+
+    const ctx = createSession('thread-1', thread, WORKSPACE);
+
+    expect(ctx.threadId).toBe('thread-1');
+    expect(ctx.session.workDir).toBe(WORKSPACE.path);
+    expect(ctx.session.workspaceName).toBe(WORKSPACE.name);
+    expect(ctx.session.sessionId).toBeNull();
+    expect(ctx.orchestrator).toBeDefined();
+    expect(ctx.claudeProcess).toBeDefined();
+    expect(typeof ctx.setAuthorId).toBe('function');
+  });
+
+  it('生成された SessionContext を SessionManager に登録する', () => {
+    const createSession = createSessionFactory({
+      config: { claudePath: '/usr/bin/claude' },
+      sessionManager,
+      usageFetcher,
+      titleGenerator: null,
+    });
+
+    const ctx = createSession('thread-42', thread, WORKSPACE);
+
+    expect(sessionManager.get('thread-42')).toBe(ctx);
+    expect(sessionManager.size()).toBe(1);
+  });
+
+  it('ClaudeProcess に config.claudePath が渡される', () => {
+    const createSession = createSessionFactory({
+      config: { claudePath: '/custom/path/to/claude' },
+      sessionManager,
+      usageFetcher,
+      titleGenerator: null,
+    });
+
+    const ctx = createSession('thread-1', thread, WORKSPACE);
+    const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+
+    expect(mockProc.claudePath).toBe('/custom/path/to/claude');
+  });
+
+  it('titleGenerator が null でも例外なく動作する', () => {
+    const createSession = createSessionFactory({
+      config: { claudePath: '/usr/bin/claude' },
+      sessionManager,
+      usageFetcher,
+      titleGenerator: null,
+    });
+
+    expect(() => createSession('thread-1', thread, WORKSPACE)).not.toThrow();
+  });
+
+  it('setAuthorId を経由したメンション設定が後続の送信に反映される', async () => {
+    const createSession = createSessionFactory({
+      config: { claudePath: '/usr/bin/claude' },
+      sessionManager,
+      usageFetcher,
+      titleGenerator: null,
+    });
+
+    const ctx = createSession('thread-1', thread, WORKSPACE);
+    ctx.setAuthorId('user-123');
+    ctx.session.ensure();
+
+    // エラー通知を notifier 経由で送ると、mention 付きで送信される。
+    // まず result をバッファし、その後 usage でフラッシュさせる。
+    const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+    mockProc.onProcessEnd(1, 'エラー詳細');
+
+    await flushAsync();
+
+    const sendMock = vi.mocked(thread.send);
+    expect(sendMock).toHaveBeenCalled();
+    // 最後の送信が mention 付きで行われることを検証
+    const lastCall = sendMock.mock.calls[sendMock.mock.calls.length - 1][0];
+    if (typeof lastCall === 'string') {
+      expect(lastCall).toContain('<@user-123>');
+    } else {
+      expect(lastCall.content).toContain('<@user-123>');
+    }
+  });
+
+  describe('プロセス終了時のタイトル生成', () => {
+    it('titleGenerator が指定され sessionId がある場合、生成されたタイトルでスレッド名を更新する', async () => {
+      const titleGenerator = createMockTitleGenerator();
+      vi.mocked(titleGenerator.generate).mockResolvedValue('テスト用タイトル');
+
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      ctx.session.ensure();
+      const sessionId = ctx.session.sessionId!;
+
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+      mockProc.onProcessEnd(0, 'output');
+
+      await flushAsync();
+
+      expect(titleGenerator.generate).toHaveBeenCalledWith(sessionId, WORKSPACE.path);
+      expect(thread.setName).toHaveBeenCalledWith('テスト用タイトル');
+    });
+
+    it('titleGenerator が null の場合はタイトル更新を試みない', async () => {
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator: null,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      ctx.session.ensure();
+
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+      mockProc.onProcessEnd(0, 'output');
+
+      await flushAsync();
+      expect(thread.setName).not.toHaveBeenCalled();
+    });
+
+    it('titleGenerator が指定されても session.sessionId が null なら呼ばない', async () => {
+      const titleGenerator = createMockTitleGenerator();
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      // session.ensure() を呼ばない → sessionId は null のまま
+
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+      mockProc.onProcessEnd(0, 'output');
+
+      await flushAsync();
+      expect(titleGenerator.generate).not.toHaveBeenCalled();
+      expect(thread.setName).not.toHaveBeenCalled();
+    });
+
+    it('titleGenerator.generate が null を返した場合はスレッド名を更新しない', async () => {
+      const titleGenerator = createMockTitleGenerator();
+      vi.mocked(titleGenerator.generate).mockResolvedValueOnce(null);
+
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      ctx.session.ensure();
+
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+      mockProc.onProcessEnd(0, 'output');
+
+      await flushAsync();
+      expect(thread.setName).not.toHaveBeenCalled();
+    });
+
+    it('titleGenerator.generate が reject してもエラーを伝播させない', async () => {
+      const titleGenerator = createMockTitleGenerator();
+      vi.mocked(titleGenerator.generate).mockRejectedValueOnce(new Error('API error'));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      ctx.session.ensure();
+
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+      expect(() => mockProc.onProcessEnd(0, 'output')).not.toThrow();
+
+      await flushAsync();
+      expect(thread.setName).not.toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('thread.setName が reject してもエラーを伝播させない', async () => {
+      const titleGenerator = createMockTitleGenerator();
+      vi.mocked(thread.setName).mockRejectedValueOnce(new Error('Discord error'));
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      ctx.session.ensure();
+
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+      mockProc.onProcessEnd(0, 'output');
+
+      await flushAsync();
+      // 例外が伝播しなければ成功
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('Orchestrator / Notifier との配線', () => {
+    it('ClaudeProcess の onProgress コールバックが notifier に届き、started で typing が始まる', () => {
+      const createSession = createSessionFactory({
+        config: { claudePath: '/usr/bin/claude' },
+        sessionManager,
+        usageFetcher,
+        titleGenerator: null,
+      });
+
+      const ctx = createSession('thread-1', thread, WORKSPACE);
+      const mockProc = ctx.claudeProcess as unknown as MockClaudeProcessLike;
+
+      mockProc.onProgress({ kind: 'started' });
+
+      expect(thread.sendTyping).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('createPersistMapping', () => {
+  it('ThreadMappingStore.set に正しい引数を渡す', async () => {
+    const mockStore = {
+      set: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ThreadMappingStore;
+
+    const persistMapping = createPersistMapping(mockStore);
+    await persistMapping('thread-1', 'session-abc', {
+      name: 'my-ws',
+      path: '/home/user/ws',
+    });
+
+    expect(mockStore.set).toHaveBeenCalledWith('thread-1', {
+      sessionId: 'session-abc',
+      workDir: '/home/user/ws',
+      workspaceName: 'my-ws',
+    });
+  });
+
+  it('ThreadMappingStore.set の Promise を返す', async () => {
+    const mockStore = {
+      set: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ThreadMappingStore;
+
+    const persistMapping = createPersistMapping(mockStore);
+    const result = persistMapping('t', 's', { name: 'w', path: '/w' });
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('複数回の呼び出しをそれぞれ別の set 呼び出しとして処理する', async () => {
+    const mockStore = {
+      set: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ThreadMappingStore;
+
+    const persistMapping = createPersistMapping(mockStore);
+    await persistMapping('t1', 's1', { name: 'w1', path: '/w1' });
+    await persistMapping('t2', 's2', { name: 'w2', path: '/w2' });
+
+    expect(mockStore.set).toHaveBeenCalledTimes(2);
+    expect(mockStore.set).toHaveBeenNthCalledWith(1, 't1', {
+      sessionId: 's1',
+      workDir: '/w1',
+      workspaceName: 'w1',
+    });
+    expect(mockStore.set).toHaveBeenNthCalledWith(2, 't2', {
+      sessionId: 's2',
+      workDir: '/w2',
+      workspaceName: 'w2',
+    });
+  });
+});

--- a/server/src/discord/session-factory.ts
+++ b/server/src/discord/session-factory.ts
@@ -6,7 +6,7 @@ import { ClaudeProcess } from '../infrastructure/claude-process.js';
 import type { Config } from '../infrastructure/config.js';
 import { createNotifier, type ThreadSender } from '../infrastructure/discord-notifier.js';
 import type { ITitleGenerator } from '../infrastructure/title-generator.js';
-import { ThreadMappingStore } from '../infrastructure/thread-mapping-store.js';
+import type { ThreadMappingStore } from '../infrastructure/thread-mapping-store.js';
 import { log, logNotification } from '../helpers.js';
 
 export interface SessionFactoryDeps {

--- a/server/src/discord/session-factory.ts
+++ b/server/src/discord/session-factory.ts
@@ -34,6 +34,10 @@ export function createSessionFactory(deps: SessionFactoryDeps): CreateSessionFn 
   return (threadId, thread, workspace) => {
     const session = new Session(workspace.path, workspace.name);
 
+    // Orchestrator は ClaudeProcess を必要とし、ClaudeProcess のコールバックは
+    // Orchestrator を必要とする循環依存のため、ここで no-op プレースホルダを作り、
+    // Orchestrator 生成後に再代入する (ClaudeProcess.spawn() が呼ばれるのは
+    // Orchestrator 経由なので、実行時に no-op が呼ばれることはない)。
     let onProgress: (event: ProgressEvent) => void = () => {};
     let onProcessEnd: (exitCode: number, output: string) => void = () => {};
 

--- a/server/src/discord/session-factory.ts
+++ b/server/src/discord/session-factory.ts
@@ -1,0 +1,106 @@
+import { Orchestrator } from '../domain/orchestrator.js';
+import { Session } from '../domain/session.js';
+import { SessionManager, type SessionContext } from '../domain/session-manager.js';
+import type { IUsageFetcher, Notification, ProgressEvent, Workspace } from '../domain/types.js';
+import { ClaudeProcess } from '../infrastructure/claude-process.js';
+import type { Config } from '../infrastructure/config.js';
+import { createNotifier, type ThreadSender } from '../infrastructure/discord-notifier.js';
+import type { ITitleGenerator } from '../infrastructure/title-generator.js';
+import { ThreadMappingStore } from '../infrastructure/thread-mapping-store.js';
+import { log, logNotification } from '../helpers.js';
+
+export interface SessionFactoryDeps {
+  config: Pick<Config, 'claudePath'>;
+  sessionManager: SessionManager;
+  usageFetcher: IUsageFetcher;
+  titleGenerator: ITitleGenerator | null;
+}
+
+export type CreateSessionFn = (
+  threadId: string,
+  thread: ThreadSender,
+  workspace: Workspace,
+) => SessionContext;
+
+/**
+ * SessionContext を組み立てて SessionManager に登録する関数を生成する。
+ *
+ * 以下の依存オブジェクトをクロージャに取り込み、呼び出し側は
+ * (threadId, thread, workspace) を渡すだけで良い形にする。
+ */
+export function createSessionFactory(deps: SessionFactoryDeps): CreateSessionFn {
+  const { config, sessionManager, usageFetcher, titleGenerator } = deps;
+
+  return (threadId, thread, workspace) => {
+    const session = new Session(workspace.path, workspace.name);
+
+    let onProgress: (event: ProgressEvent) => void = () => {};
+    let onProcessEnd: (exitCode: number, output: string) => void = () => {};
+
+    const claudeProcess = new ClaudeProcess(
+      config.claudePath,
+      (event) => onProgress(event),
+      (exitCode, output) => onProcessEnd(exitCode, output),
+    );
+
+    const notifier = createNotifier(thread);
+    const notify = (notification: Notification): void => {
+      logNotification(notification);
+      notifier.notify(notification);
+    };
+
+    const orchestrator = new Orchestrator(session, claudeProcess, notify, usageFetcher);
+
+    onProgress = (event) => orchestrator.onProgress(event);
+    onProcessEnd = (exitCode, output) => {
+      log(`ClaudeProcess 終了 (exitCode: ${exitCode}, thread: ${threadId})`);
+      orchestrator.onProcessEnd(exitCode, output);
+      notifier.dispose();
+
+      // タイトル生成（非同期・失敗しても無視）
+      if (titleGenerator && session.sessionId) {
+        titleGenerator
+          .generate(session.sessionId, session.workDir)
+          .then((title) => {
+            if (title) {
+              log(`タイトル生成: "${title}" (thread: ${threadId})`);
+              thread
+                .setName(title)
+                .catch((err: unknown) => console.error('Thread setName error:', err));
+            }
+          })
+          .catch((err) => console.error('Title generation error:', err));
+      }
+    };
+
+    const ctx: SessionContext = {
+      orchestrator,
+      session,
+      claudeProcess,
+      threadId,
+      setAuthorId: (authorId) => notifier.setAuthorId(authorId),
+    };
+    sessionManager.register(threadId, ctx);
+    return ctx;
+  };
+}
+
+export type PersistMappingFn = (
+  threadId: string,
+  sessionId: string,
+  workspace: Workspace,
+) => Promise<void>;
+
+/**
+ * threadId ↔ sessionId/workDir/workspaceName のマッピングをディスクに
+ * 書き込むコールバックを生成する。サーバー再起動後のセッション復元
+ * (docs/19_Session_Persistence) の根幹となる処理。
+ */
+export function createPersistMapping(threadMappingStore: ThreadMappingStore): PersistMappingFn {
+  return (threadId, sessionId, workspace) =>
+    threadMappingStore.set(threadId, {
+      sessionId,
+      workDir: workspace.path,
+      workspaceName: workspace.name,
+    });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,13 +12,11 @@ import {
 import { createMessageHandler } from './app/message-handler.js';
 import { toCommand } from './app/interaction-handler.js';
 import { AccessControl } from './domain/access-control.js';
-import { Orchestrator } from './domain/orchestrator.js';
 import { Session } from './domain/session.js';
-import { SessionManager, type SessionContext } from './domain/session-manager.js';
-import type { Notification, ProgressEvent, Workspace } from './domain/types.js';
-import { ClaudeProcess } from './infrastructure/claude-process.js';
+import { SessionManager } from './domain/session-manager.js';
+import type { Workspace } from './domain/types.js';
 import { loadConfig } from './infrastructure/config.js';
-import { createNotifier, type ThreadSender } from './infrastructure/discord-notifier.js';
+import type { ThreadSender } from './infrastructure/discord-notifier.js';
 import { resolvePrompt } from './infrastructure/attachment-resolver.js';
 import { SessionStore } from './infrastructure/session-store.js';
 import { ccCommand } from './infrastructure/slash-commands.js';
@@ -33,13 +31,13 @@ import { ThreadMappingStore } from './infrastructure/thread-mapping-store.js';
 import { TurnStore } from './infrastructure/turn-store.js';
 import { SessionBrancher } from './infrastructure/session-brancher.js';
 import { WorkspaceStore, listDirectories } from './infrastructure/workspace-store.js';
+import { createSessionFactory, createPersistMapping } from './discord/session-factory.js';
 import {
   formatRelativeDate,
   todayJST,
   parseDateInput,
   generateDateChoices,
   log,
-  logNotification,
 } from './helpers.js';
 
 async function main(): Promise<void> {
@@ -87,63 +85,12 @@ async function main(): Promise<void> {
   const turnStore = new TurnStore();
   const sessionBrancher = new SessionBrancher(turnStore);
 
-  /** セッションコンテキストを作成し SessionManager に登録する */
-  function createSession(
-    threadId: string,
-    thread: ThreadSender,
-    workspace: Workspace,
-  ): SessionContext {
-    const session = new Session(workspace.path, workspace.name);
-
-    let onProgress: (event: ProgressEvent) => void = () => {};
-    let onProcessEnd: (exitCode: number, output: string) => void = () => {};
-
-    const claudeProcess = new ClaudeProcess(
-      config.claudePath,
-      (event) => onProgress(event),
-      (exitCode, output) => onProcessEnd(exitCode, output),
-    );
-
-    const notifier = createNotifier(thread);
-    const notify = (notification: Notification): void => {
-      logNotification(notification);
-      notifier.notify(notification);
-    };
-
-    const orchestrator = new Orchestrator(session, claudeProcess, notify, usageFetcher);
-
-    onProgress = (event) => orchestrator.onProgress(event);
-    onProcessEnd = (exitCode, output) => {
-      log(`ClaudeProcess 終了 (exitCode: ${exitCode}, thread: ${threadId})`);
-      orchestrator.onProcessEnd(exitCode, output);
-      notifier.dispose();
-
-      // タイトル生成（非同期・失敗しても無視）
-      if (titleGenerator && session.sessionId) {
-        titleGenerator
-          .generate(session.sessionId, session.workDir)
-          .then((title) => {
-            if (title) {
-              log(`タイトル生成: "${title}" (thread: ${threadId})`);
-              thread
-                .setName(title)
-                .catch((err: unknown) => console.error('Thread setName error:', err));
-            }
-          })
-          .catch((err) => console.error('Title generation error:', err));
-      }
-    };
-
-    const ctx: SessionContext = {
-      orchestrator,
-      session,
-      claudeProcess,
-      threadId,
-      setAuthorId: (authorId) => notifier.setAuthorId(authorId),
-    };
-    sessionManager.register(threadId, ctx);
-    return ctx;
-  }
+  const createSession = createSessionFactory({
+    config,
+    sessionManager,
+    usageFetcher,
+    titleGenerator,
+  });
 
   const sessionRestorer = new SessionRestorer({
     threadMappingStore,
@@ -152,18 +99,7 @@ async function main(): Promise<void> {
     log,
   });
 
-  /** マッピングをディスクに永続化する */
-  function persistMapping(
-    threadId: string,
-    sessionId: string,
-    workspace: Workspace,
-  ): Promise<void> {
-    return threadMappingStore.set(threadId, {
-      sessionId,
-      workDir: workspace.path,
-      workspaceName: workspace.name,
-    });
-  }
+  const persistMapping = createPersistMapping(threadMappingStore);
 
   // App 層
   const handleMessage = createMessageHandler(accessControl, sessionManager);


### PR DESCRIPTION
## Summary
- 親 issue [#16](https://github.com/manntera/chat-agent-bridge/issues/16) の Step 1
- `server/src/index.ts` の `main()` 内クロージャとして定義されていた `createSession` と `persistMapping` を、高階関数 (`createSessionFactory` / `createPersistMapping`) として切り出し、新規ファイル `server/src/discord/session-factory.ts` に移動
- 挙動は現状維持。全 451 テスト通過、typecheck / lint / format:check も通過

Closes #17

## 背景

本 PR は、Discord 固有コードを `discord/` 配下に再配置するリファクタリング (親 issue #16) の第 1 段階です。`server/src/index.ts` が 951 行に肥大化しており、`createSession` は DI ワイヤリングの中心的な処理でありながら `main()` の内部クロージャに閉じていたため、他モジュールから参照できず単体テストも書けない状態でした。

## 変更内容

### 新規ファイル
- `server/src/discord/session-factory.ts` — `createSessionFactory` / `createPersistMapping` をエクスポート
- `server/src/discord/session-factory.test.ts` — ユニットテスト 16 件

### `createSessionFactory` の設計
依存 (`config.claudePath`, `sessionManager`, `usageFetcher`, `titleGenerator`) をファクトリ引数で受け、`(threadId, thread, workspace) => SessionContext` を返す高階関数。呼び出し側は `const createSession = createSessionFactory({ ... })` の 1 行で組み立てる。

`config` は `Pick<Config, 'claudePath'>` に narrow し、必要最小限の依存を明示。`titleGenerator` は `ITitleGenerator | null` (インターフェース経由) でテスタビリティを確保。

### `createPersistMapping` の設計
`ThreadMappingStore` を受けて `(threadId, sessionId, workspace) => Promise<void>` を返すファクトリ。

### `index.ts` への影響
- 90-146 行目 `createSession` 関数本体と 156-166 行目 `persistMapping` 関数本体を削除
- 代わりに 6 行の factory 呼び出しに置換
- 不要になった import (`Orchestrator`, `ClaudeProcess`, `createNotifier`, `Notification`, `ProgressEvent`, `logNotification`) を削除
- `SessionRestorer` の `createSession` 引数に factory で生成した関数を渡す (147-155 行目は未変更)
- ファイル行数: 951 → 890 行 (-61 行)

## テスト

### 既存テスト
- 27 ファイル、451 件すべて通過
- `server/src/__tests__/integration.test.ts` (起動〜送受信〜終了の統合テスト) も通過

### 新規テスト (`session-factory.test.ts`) の主要シナリオ

**`createSessionFactory`:**
- 依存を受け取り SessionContext を返す関数を生成
- 生成された SessionContext が SessionManager に登録される
- `config.claudePath` が ClaudeProcess に正しく渡される
- `titleGenerator: null` でも例外なく動作
- `setAuthorId` がメンション設定として後続送信に反映される
- プロセス終了時のタイトル生成 (正常系 / null generator / sessionId null / generator が null 返却 / generator reject / setName reject)
- ClaudeProcess の onProgress コールバックが Notifier まで伝搬

**`createPersistMapping`:**
- `ThreadMappingStore.set` に正しい引数を渡す
- Promise を返す
- 複数回呼び出しをそれぞれ独立して処理

### カバレッジ
- `session-factory.ts`: Stmts 100% / Branch 100% / Lines 100% / Funcs 86.66%
- 未カバー Funcs は `onProgress`/`onProcessEnd` の初期化用 no-op arrow (Orchestrator 生成前に渡すための TDZ 対策プレースホルダで、実際には常に再代入後のものが呼ばれる)

## 検証手順
```
cd server
pnpm install
pnpm check   # typecheck + lint + format:check + test すべて通過
pnpm test:coverage   # カバレッジ確認
pnpm build   # tsc ビルドも通過
```

## 注意事項
- 実機での Discord 動作確認は本ローカル環境では未実施。マージ前にレビュアー側で `/cc new`, メッセージ送信, スレッド復元, タイトル生成などの動作確認をお願いします
- 本 PR のマージ後、Step 2 (#18) に着手可能になります

🤖 Generated with [Claude Code](https://claude.com/claude-code)