### PR TITLE
refactor: 巻き戻しロジックを discord/rewind-handler.ts に分離 (#18)

### DIFF
--- a/server/src/discord/rewind-handler.test.ts
+++ b/server/src/discord/rewind-handler.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from 'discord.js';
+import type { SessionContext } from '../domain/session-manager.js';
+import type { Command, OrchestratorState } from '../domain/types.js';
+import type { SessionBrancher } from '../infrastructure/session-brancher.js';
+import type { TurnStore } from '../infrastructure/turn-store.js';
+import type { PersistMappingFn } from './session-factory.js';
+import { createRewindHandler } from './rewind-handler.js';
+
+interface TurnStoreMock {
+  findTurn: ReturnType<typeof vi.fn>;
+  findTurnAcrossSessions: ReturnType<typeof vi.fn>;
+}
+
+interface BrancherMock {
+  branch: ReturnType<typeof vi.fn>;
+}
+
+interface MessageStub {
+  channelId: string;
+  reference: { messageId: string } | null;
+  channel: { send: ReturnType<typeof vi.fn> };
+}
+
+interface CtxStub {
+  session: {
+    sessionId: string | null;
+    workDir: string;
+    workspaceName: string;
+  };
+  orchestrator: {
+    state: OrchestratorState;
+    handleCommand: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeTurnStore(): TurnStoreMock {
+  return {
+    findTurn: vi.fn().mockResolvedValue(null),
+    findTurnAcrossSessions: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function makeBrancher(): BrancherMock {
+  return {
+    branch: vi.fn().mockResolvedValue('new-session-id'),
+  };
+}
+
+function makeMessage(
+  options: {
+    channelId?: string;
+    referencedId?: string | null;
+  } = {},
+): MessageStub {
+  const { channelId = 'thread-1', referencedId = 'ref-msg-1' } = options;
+  return {
+    channelId,
+    reference: referencedId === null ? null : { messageId: referencedId },
+    channel: { send: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+function makeCtx(
+  options: {
+    sessionId?: string | null;
+    state?: OrchestratorState;
+    workDir?: string;
+    workspaceName?: string;
+  } = {},
+): CtxStub {
+  const {
+    sessionId = 'current-session-id',
+    state = 'idle',
+    workDir = '/ws/path',
+    workspaceName = 'ws-name',
+  } = options;
+  return {
+    session: { sessionId, workDir, workspaceName },
+    orchestrator: { state, handleCommand: vi.fn() },
+  };
+}
+
+function coerceMessage(m: MessageStub): Message {
+  return m as unknown as Message;
+}
+
+function coerceCtx(c: CtxStub): SessionContext {
+  return c as unknown as SessionContext;
+}
+
+function coerceTurnStore(t: TurnStoreMock): TurnStore {
+  return t as unknown as TurnStore;
+}
+
+function coerceBrancher(b: BrancherMock): SessionBrancher {
+  return b as unknown as SessionBrancher;
+}
+
+describe('createRewindHandler', () => {
+  let turnStore: TurnStoreMock;
+  let brancher: BrancherMock;
+  let persistMapping: ReturnType<typeof vi.fn<PersistMappingFn>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    turnStore = makeTurnStore();
+    brancher = makeBrancher();
+    persistMapping = vi.fn<PersistMappingFn>().mockResolvedValue(undefined);
+  });
+
+  function makeHandler() {
+    return createRewindHandler({
+      turnStore: coerceTurnStore(turnStore),
+      sessionBrancher: coerceBrancher(brancher),
+      persistMapping,
+    });
+  }
+
+  it('リプライがない場合は handled: false を返し、副作用を起こさない', async () => {
+    const handler = makeHandler();
+    const msg = makeMessage({ referencedId: null });
+    const ctx = makeCtx();
+
+    const result = await handler(coerceMessage(msg), coerceCtx(ctx), 'hello');
+
+    expect(result).toEqual({ handled: false });
+    expect(turnStore.findTurn).not.toHaveBeenCalled();
+    expect(turnStore.findTurnAcrossSessions).not.toHaveBeenCalled();
+    expect(brancher.branch).not.toHaveBeenCalled();
+    expect(persistMapping).not.toHaveBeenCalled();
+    expect(ctx.orchestrator.handleCommand).not.toHaveBeenCalled();
+  });
+
+  it('ctx が null の場合は handled: false を返す', async () => {
+    const handler = makeHandler();
+    const msg = makeMessage();
+
+    const result = await handler(coerceMessage(msg), null, 'hello');
+
+    expect(result).toEqual({ handled: false });
+    expect(turnStore.findTurn).not.toHaveBeenCalled();
+  });
+
+  it('session.sessionId が null の場合は handled: false を返す', async () => {
+    const handler = makeHandler();
+    const msg = makeMessage();
+    const ctx = makeCtx({ sessionId: null });
+
+    const result = await handler(coerceMessage(msg), coerceCtx(ctx), 'hello');
+
+    expect(result).toEqual({ handled: false });
+    expect(turnStore.findTurn).not.toHaveBeenCalled();
+  });
+
+  it('リプライ先のターンが現セッションにも他セッションにも見つからなければ handled: false', async () => {
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(null);
+    turnStore.findTurnAcrossSessions.mockResolvedValueOnce(null);
+
+    const result = await handler(coerceMessage(makeMessage()), coerceCtx(makeCtx()), 'hello');
+
+    expect(result).toEqual({ handled: false });
+    expect(brancher.branch).not.toHaveBeenCalled();
+    expect(persistMapping).not.toHaveBeenCalled();
+  });
+
+  it('idle 状態でターンが見つかった場合、branch → rewind コマンド発行 → マッピング保存し handled: true', async () => {
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(5);
+    brancher.branch.mockResolvedValueOnce('new-session-xyz');
+
+    const msg = makeMessage({ channelId: 'ch-42', referencedId: 'ref-1' });
+    const ctx = makeCtx({
+      sessionId: 'src-session',
+      state: 'idle',
+      workDir: '/work',
+      workspaceName: 'ws',
+    });
+
+    const result = await handler(coerceMessage(msg), coerceCtx(ctx), 'override prompt');
+
+    expect(result).toEqual({ handled: true });
+    expect(turnStore.findTurn).toHaveBeenCalledWith('src-session', '/work', 'ref-1');
+    expect(turnStore.findTurnAcrossSessions).not.toHaveBeenCalled();
+    expect(brancher.branch).toHaveBeenCalledWith('src-session', '/work', 4);
+    expect(ctx.orchestrator.handleCommand).toHaveBeenCalledWith({
+      type: 'rewind',
+      targetTurn: 4,
+      newSessionId: 'new-session-xyz',
+      prompt: 'override prompt',
+    } satisfies Command);
+    expect(persistMapping).toHaveBeenCalledWith('ch-42', 'new-session-xyz', {
+      path: '/work',
+      name: 'ws',
+    });
+  });
+
+  it('現セッションで見つからないが横断検索で見つかった場合、そのセッションを branch 元にする', async () => {
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(null);
+    turnStore.findTurnAcrossSessions.mockResolvedValueOnce({
+      sessionId: 'other-session',
+      turn: 3,
+    });
+    brancher.branch.mockResolvedValueOnce('branched-from-other');
+
+    const ctx = makeCtx({ sessionId: 'current', state: 'idle', workDir: '/w' });
+    const result = await handler(coerceMessage(makeMessage()), coerceCtx(ctx), 'p');
+
+    expect(result).toEqual({ handled: true });
+    expect(brancher.branch).toHaveBeenCalledWith('other-session', '/w', 2);
+    expect(ctx.orchestrator.handleCommand).toHaveBeenCalledWith({
+      type: 'rewind',
+      targetTurn: 2,
+      newSessionId: 'branched-from-other',
+      prompt: 'p',
+    } satisfies Command);
+  });
+
+  it('busy 状態では branch せず、newSessionId 空の rewind コマンドのみ発行して handled: true', async () => {
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(7);
+    const ctx = makeCtx({ state: 'busy' });
+
+    const result = await handler(coerceMessage(makeMessage()), coerceCtx(ctx), 'mid-run prompt');
+
+    expect(result).toEqual({ handled: true });
+    expect(brancher.branch).not.toHaveBeenCalled();
+    expect(persistMapping).not.toHaveBeenCalled();
+    expect(ctx.orchestrator.handleCommand).toHaveBeenCalledWith({
+      type: 'rewind',
+      targetTurn: 6,
+      newSessionId: '',
+      prompt: 'mid-run prompt',
+    } satisfies Command);
+  });
+
+  it('interrupting 状態でも branch せず通知のみ', async () => {
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(2);
+    const ctx = makeCtx({ state: 'interrupting' });
+
+    const result = await handler(coerceMessage(makeMessage()), coerceCtx(ctx), 'q');
+
+    expect(result).toEqual({ handled: true });
+    expect(brancher.branch).not.toHaveBeenCalled();
+    expect(ctx.orchestrator.handleCommand).toHaveBeenCalledWith({
+      type: 'rewind',
+      targetTurn: 1,
+      newSessionId: '',
+      prompt: 'q',
+    } satisfies Command);
+  });
+
+  it('branch() が throw した場合はエラーログと Discord 通知を行い handled: true を返す', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(3);
+    const branchError = new Error('branch failed');
+    brancher.branch.mockRejectedValueOnce(branchError);
+
+    const msg = makeMessage();
+    const ctx = makeCtx({ state: 'idle' });
+    const result = await handler(coerceMessage(msg), coerceCtx(ctx), 'p');
+
+    expect(result).toEqual({ handled: true });
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Rewind error:', branchError);
+    expect(msg.channel.send).toHaveBeenCalledWith('巻き戻しに失敗しました');
+    expect(persistMapping).not.toHaveBeenCalled();
+    expect(ctx.orchestrator.handleCommand).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('branch は成功したが Discord 通知送信が reject しても例外を伝播させない', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(3);
+    brancher.branch.mockRejectedValueOnce(new Error('boom'));
+
+    const msg = makeMessage();
+    msg.channel.send.mockRejectedValueOnce(new Error('discord down'));
+
+    await expect(
+      handler(coerceMessage(msg), coerceCtx(makeCtx({ state: 'idle' })), 'p'),
+    ).resolves.toEqual({ handled: true });
+
+    expect(msg.channel.send).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('channel が send を持たない型 (例: PartialGroupDMChannel) の場合、エラー通知送信を試みない', async () => {
+    // 実際の MessageCreate 経路ではスレッドチャンネルに絞り込み済みのため発生しないが、
+    // 型安全のためのガードが機能していることを確認する
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = makeHandler();
+    turnStore.findTurn.mockResolvedValueOnce(3);
+    brancher.branch.mockRejectedValueOnce(new Error('boom'));
+
+    const msg = {
+      channelId: 'thread-1',
+      reference: { messageId: 'r' },
+      channel: {},
+    } as unknown as Message;
+
+    const result = await handler(msg, coerceCtx(makeCtx({ state: 'idle' })), 'p');
+
+    expect(result).toEqual({ handled: true });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/server/src/discord/rewind-handler.ts
+++ b/server/src/discord/rewind-handler.ts
@@ -1,0 +1,91 @@
+import type { Message } from 'discord.js';
+import type { SessionContext } from '../domain/session-manager.js';
+import type { SessionBrancher } from '../infrastructure/session-brancher.js';
+import type { TurnStore } from '../infrastructure/turn-store.js';
+import { log } from '../helpers.js';
+import type { PersistMappingFn } from './session-factory.js';
+
+export interface RewindHandlerDeps {
+  turnStore: TurnStore;
+  sessionBrancher: SessionBrancher;
+  persistMapping: PersistMappingFn;
+}
+
+export type RewindHandlerFn = (
+  msg: Message,
+  ctx: SessionContext | null,
+  prompt: string,
+) => Promise<{ handled: boolean }>;
+
+/**
+ * Bot の過去応答に対するリプライを検出し、該当ターンまで会話を巻き戻した
+ * 新セッションを発行する。詳細は docs/17_Conversation_Rewind.md を参照。
+ *
+ * 戻り値の `handled` が true の場合、呼び出し側 (MessageCreate ハンドラ) は
+ * 通常のメッセージ処理をスキップする。
+ */
+export function createRewindHandler(deps: RewindHandlerDeps): RewindHandlerFn {
+  const { turnStore, sessionBrancher, persistMapping } = deps;
+
+  return async (msg, ctx, prompt) => {
+    if (!msg.reference?.messageId || !ctx?.session.sessionId) {
+      return { handled: false };
+    }
+
+    const referencedId = msg.reference.messageId;
+
+    let sourceSessionId = ctx.session.sessionId;
+    let turn = await turnStore.findTurn(sourceSessionId, ctx.session.workDir, referencedId);
+    if (turn === null) {
+      const found = await turnStore.findTurnAcrossSessions(ctx.session.workDir, referencedId);
+      if (found) {
+        sourceSessionId = found.sessionId;
+        turn = found.turn;
+      }
+    }
+
+    if (turn === null) {
+      return { handled: false };
+    }
+
+    const branchTurn = turn - 1;
+
+    if (ctx.orchestrator.state !== 'idle') {
+      ctx.orchestrator.handleCommand({
+        type: 'rewind',
+        targetTurn: branchTurn,
+        newSessionId: '',
+        prompt,
+      });
+      return { handled: true };
+    }
+
+    try {
+      const newSessionId = await sessionBrancher.branch(
+        sourceSessionId,
+        ctx.session.workDir,
+        branchTurn,
+      );
+      log(
+        `巻き戻し: Turn ${turn} を上書き (元セッション: ${sourceSessionId.slice(0, 8)}) → 新セッション ${newSessionId.slice(0, 8)} (thread: ${msg.channelId})`,
+      );
+      ctx.orchestrator.handleCommand({
+        type: 'rewind',
+        targetTurn: branchTurn,
+        newSessionId,
+        prompt,
+      });
+      await persistMapping(msg.channelId, newSessionId, {
+        path: ctx.session.workDir,
+        name: ctx.session.workspaceName,
+      });
+    } catch (err) {
+      console.error('Rewind error:', err);
+      if ('send' in msg.channel) {
+        msg.channel.send('巻き戻しに失敗しました').catch(() => {});
+      }
+    }
+
+    return { handled: true };
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { TurnStore } from './infrastructure/turn-store.js';
 import { SessionBrancher } from './infrastructure/session-brancher.js';
 import { WorkspaceStore, listDirectories } from './infrastructure/workspace-store.js';
 import { createSessionFactory, createPersistMapping } from './discord/session-factory.js';
+import { createRewindHandler } from './discord/rewind-handler.js';
 import {
   formatRelativeDate,
   todayJST,
@@ -101,6 +102,8 @@ async function main(): Promise<void> {
 
   const persistMapping = createPersistMapping(threadMappingStore);
 
+  const rewindHandler = createRewindHandler({ turnStore, sessionBrancher, persistMapping });
+
   // App 層
   const handleMessage = createMessageHandler(accessControl, sessionManager);
 
@@ -148,66 +151,8 @@ async function main(): Promise<void> {
       ctx.setAuthorId(msg.author.id);
     }
 
-    // リプライ検出（質問上書きによる巻き戻し）
-    if (msg.reference?.messageId && ctx?.session.sessionId) {
-      const referencedId = msg.reference.messageId;
-
-      // 現セッション → 全セッション横断の順で検索
-      let sourceSessionId = ctx.session.sessionId;
-      let turn = await turnStore.findTurn(sourceSessionId, ctx.session.workDir, referencedId);
-
-      if (turn === null) {
-        const found = await turnStore.findTurnAcrossSessions(ctx.session.workDir, referencedId);
-        if (found) {
-          sourceSessionId = found.sessionId;
-          turn = found.turn;
-        }
-      }
-
-      if (turn !== null) {
-        // リプライ先の質問の直前まで保持し、新しいプロンプトで上書き
-        const branchTurn = turn - 1;
-
-        // busy/interrupting 時は branch せず通知のみ（Orchestrator 側で処理）
-        if (ctx.orchestrator.state !== 'idle') {
-          ctx.orchestrator.handleCommand({
-            type: 'rewind',
-            targetTurn: branchTurn,
-            newSessionId: '', // busy 時は Orchestrator が拒否するため使われない
-            prompt,
-          });
-          return;
-        }
-
-        try {
-          const newSessionId = await sessionBrancher.branch(
-            sourceSessionId,
-            ctx.session.workDir,
-            branchTurn,
-          );
-          log(
-            `巻き戻し: Turn ${turn} を上書き (元セッション: ${sourceSessionId.slice(0, 8)}) → 新セッション ${newSessionId.slice(0, 8)} (thread: ${msg.channelId})`,
-          );
-
-          ctx.orchestrator.handleCommand({
-            type: 'rewind',
-            targetTurn: branchTurn,
-            newSessionId,
-            prompt,
-          });
-
-          await persistMapping(msg.channelId, newSessionId, {
-            path: ctx.session.workDir,
-            name: ctx.session.workspaceName,
-          });
-        } catch (err) {
-          console.error('Rewind error:', err);
-          msg.channel.send('巻き戻しに失敗しました').catch(() => {});
-        }
-        return;
-      }
-      // turn が見つからない場合 → 通常メッセージとして処理
-    }
+    const rewindResult = await rewindHandler(msg, ctx, prompt);
+    if (rewindResult.handled) return;
 
     const prevState = ctx?.orchestrator.state;
 


### PR DESCRIPTION
## Summary
- 親 issue [#16](https://github.com/manntera/chat-agent-bridge/issues/16) の Step 2
- `server/src/index.ts` の `MessageCreate` ハンドラ内に直書きされていた 60 行の会話巻き戻しロジックを、高階関数 `createRewindHandler` として切り出し、新規ファイル `server/src/discord/rewind-handler.ts` に移動
- 挙動は現状維持。全 472 テスト通過、typecheck / lint / format:check / build もすべて通過

Closes #18

## 背景

本 PR は、Discord 固有コードを `discord/` 配下に再配置するリファクタリング (親 issue #16) の第 2 段階です。巻き戻し機能 (`docs/17_Conversation_Rewind.md`) は Bot の過去応答にリプライして会話を特定ターンまで巻き戻す機能で、`MessageCreate` ハンドラの中央に 60 行のロジックとして埋め込まれていました。「ユーザー発言をセッションに中継する」という本来責務と、「高度な特殊ケースとしての巻き戻し」が同居していたため、Step 3 (`message-controller.ts` の抽出) に進む前に独立モジュールへ分離します。

## 変更内容

### 新規ファイル
- `server/src/discord/rewind-handler.ts` — `createRewindHandler` をエクスポート
- `server/src/discord/rewind-handler.test.ts` — ユニットテスト 11 件

### `createRewindHandler` の設計
依存 (`turnStore`, `sessionBrancher`, `persistMapping`) を受け取り、`(msg, ctx, prompt) => Promise<{ handled: boolean }>` を返す高階関数。`handled: true` の場合、呼び出し側 (`MessageCreate` ハンドラ) は通常メッセージ処理をスキップする。

`PersistMappingFn` 型は Step 1 で確立した `discord/session-factory.ts` から import して再利用 (単一の型定義源を維持)。

`handled` フラグによる短絡制御は、issue 本文で示された設計パターンをそのまま踏襲しました。

### 主要分岐
- リプライなし / `ctx` null / `session.sessionId` null → `handled: false` で通常処理へ
- 現セッションで turn 未検出 → `findTurnAcrossSessions` フォールバック
- いずれでも未検出 → `handled: false` で通常処理へ
- `idle` 状態 → `sessionBrancher.branch()` で新セッション発行 → `rewind` コマンド → `persistMapping` 保存
- `busy` / `interrupting` 状態 → branch せず `rewind` コマンドのみ発行 (空 `newSessionId` は Orchestrator 側が拒否)
- `branch()` が throw → `console.error` + `msg.channel.send('巻き戻しに失敗しました')`

### `index.ts` への影響
- 151-210 行目 (60 行) の巻き戻しロジックを削除
- DI 部に `const rewindHandler = createRewindHandler({ turnStore, sessionBrancher, persistMapping });` を追加
- `MessageCreate` ハンドラ内は `const rewindResult = await rewindHandler(msg, ctx, prompt); if (rewindResult.handled) return;` の 2 行に集約
- ファイル行数: 887 → 832 行 (-55 行)

### 設計判断: `msg.channel.send` の型ガード

issue 本文の疑似コードは `msg.channel.send('巻き戻しに失敗しました').catch(() => {})` となっていますが、ファクトリの外部公開面では `msg: Message` 型のまま受けるため、`msg.channel` の型は `PartialGroupDMChannel` も含むユニオンに展開され、`.send` が存在しないと TS エラーになります。これを回避するため `'send' in msg.channel` で型ガードを 1 行追加しました (`rewind-handler.ts:84`)。

`MessageCreate` ハンドラ側のプロセッサフィルタ (スレッド以外を早期 return) により実行時は常にガード内に入りますが、ファクトリの型安全性を保つための最小限の変更です。Step 3 で `message-controller.ts` に統合する際、`msg` の型をスレッドメッセージに narrow して渡す形にリファクタしても構いません。

## テスト

### 既存テスト
- 28 ファイル、461 → 472 件すべて通過 (+11 新規)
- 既存のセッション統合テストにも影響なし

### 新規テスト (`rewind-handler.test.ts`) の主要シナリオ
- リプライなし → `handled: false`、`turnStore` も呼ばない
- `ctx` null → `handled: false`
- `session.sessionId` null → `handled: false`
- 現セッション・横断検索とも turn 未検出 → `handled: false`
- idle + turn 検出 → `sessionBrancher.branch()` + `rewind` コマンド + `persistMapping` 呼び出し
- 横断検索ヒット → そのセッション ID を branch 元にする
- `busy` 状態 → branch せず `rewind` コマンドのみ (`newSessionId` 空)
- `interrupting` 状態 → 同上
- `branch()` が throw → エラーログ + Discord 通知 + `handled: true`
- Discord `send` 自体が reject しても例外が伝播しない
- `msg.channel` が `send` を持たない型 (`PartialGroupDMChannel`) でも落ちない (型ガードの検証)

### カバレッジ
- `rewind-handler.ts`: Stmts 100% / Branch 100% / Lines 100% / Funcs 100%

## 検証手順
```sh
cd server
pnpm install
pnpm run typecheck
pnpm run lint
pnpm run format:check
pnpm run test
pnpm run test:coverage
pnpm run build
```

## 注意事項
- Discord 上での実機動作確認はローカル環境の制約により本 PR では未実施です。マージ前に手動での巻き戻し動作 (Bot 応答へのリプライでの上書き) 検証をお願いします。
- 本 PR で解放される後続作業: #19 Step 3 (`message-controller.ts` の抽出) が着手可能になります。
