### PR TITLE
refactor: MessageCreate ハンドラを discord/message-controller.ts に分離 (#19)

### DIFF
--- a/server/src/discord/message-controller.test.ts
+++ b/server/src/discord/message-controller.test.ts
@@ -323,9 +323,7 @@ describe('createMessageController', () => {
     const controller = makeController();
     await controller(makeMessage({ content: longContent }));
 
-    expect(handleMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ content: longContent }),
-    );
+    expect(handleMessage).toHaveBeenCalledWith(expect.objectContaining({ content: longContent }));
   });
 
   it('turnStore.record が reject しても例外を伝播させない', async () => {

--- a/server/src/discord/message-controller.test.ts
+++ b/server/src/discord/message-controller.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChannelType, type Message } from 'discord.js';
+import type { MessageHandlerFn } from '../app/message-handler.js';
+import type { SessionContext, SessionManager } from '../domain/session-manager.js';
+import type { OrchestratorState } from '../domain/types.js';
+import type { SessionRestorer } from '../infrastructure/session-restorer.js';
+import type { TurnStore } from '../infrastructure/turn-store.js';
+import { createMessageController } from './message-controller.js';
+import type { RewindHandlerFn } from './rewind-handler.js';
+
+vi.mock('../infrastructure/attachment-resolver.js', () => ({
+  resolvePrompt: vi
+    .fn<
+      (
+        content: string,
+        attachments: unknown[],
+      ) => Promise<{ prompt: string | null; error: string | null }>
+    >()
+    .mockImplementation(async (content) => ({ prompt: content, error: null })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const resolvePromptModule: any = await import('../infrastructure/attachment-resolver.js');
+const mockedResolvePrompt = resolvePromptModule.resolvePrompt as ReturnType<typeof vi.fn>;
+
+interface CtxStub {
+  session: { sessionId: string | null; workDir: string; workspaceName: string };
+  orchestrator: { state: OrchestratorState; currentTurn: number };
+  setAuthorId: ReturnType<typeof vi.fn>;
+}
+
+function makeCtx(
+  options: {
+    sessionId?: string | null;
+    state?: OrchestratorState;
+    currentTurn?: number;
+  } = {},
+): CtxStub {
+  const { sessionId = 'sess-1', state = 'idle', currentTurn = 0 } = options;
+  return {
+    session: { sessionId, workDir: '/work', workspaceName: 'ws' },
+    orchestrator: { state, currentTurn },
+    setAuthorId: vi.fn(),
+  };
+}
+
+function coerceCtx(c: CtxStub): SessionContext {
+  return c as unknown as SessionContext;
+}
+
+interface MessageStubOptions {
+  authorBot?: boolean;
+  authorId?: string;
+  authorUsername?: string;
+  channelType?: ChannelType;
+  parentId?: string | null;
+  channelId?: string;
+  messageId?: string;
+  content?: string;
+  attachments?: Map<
+    string,
+    { contentType: string | null; name: string | null; size: number; url: string }
+  >;
+}
+
+function makeMessage(opts: MessageStubOptions = {}): Message {
+  const {
+    authorBot = false,
+    authorId = 'user-1',
+    authorUsername = 'alice',
+    channelType = ChannelType.PublicThread,
+    parentId = 'parent-channel',
+    channelId = 'thread-1',
+    messageId = 'msg-1',
+    content = 'hello',
+    attachments = new Map(),
+  } = opts;
+
+  const channelSend = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    author: { bot: authorBot, id: authorId, username: authorUsername },
+    channel: { type: channelType, parentId, send: channelSend },
+    channelId,
+    id: messageId,
+    content,
+    attachments,
+  } as unknown as Message;
+}
+
+function channelSendOf(msg: Message): ReturnType<typeof vi.fn> {
+  return (msg.channel as unknown as { send: ReturnType<typeof vi.fn> }).send;
+}
+
+describe('createMessageController', () => {
+  let sessionManager: { get: ReturnType<typeof vi.fn> };
+  let sessionRestorer: { tryRestore: ReturnType<typeof vi.fn> };
+  let rewindHandler: ReturnType<typeof vi.fn<RewindHandlerFn>>;
+  let turnStore: { record: ReturnType<typeof vi.fn> };
+  let handleMessage: ReturnType<typeof vi.fn<MessageHandlerFn>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionManager = { get: vi.fn().mockReturnValue(null) };
+    sessionRestorer = { tryRestore: vi.fn().mockResolvedValue(null) };
+    rewindHandler = vi.fn<RewindHandlerFn>().mockResolvedValue({ handled: false });
+    turnStore = { record: vi.fn().mockResolvedValue(undefined) };
+    handleMessage = vi.fn<MessageHandlerFn>();
+    mockedResolvePrompt.mockImplementation(async (content: string) => ({
+      prompt: content,
+      error: null,
+    }));
+  });
+
+  function makeController() {
+    return createMessageController({
+      sessionManager: sessionManager as unknown as SessionManager,
+      sessionRestorer: sessionRestorer as unknown as SessionRestorer,
+      rewindHandler,
+      turnStore: turnStore as unknown as TurnStore,
+      handleMessage,
+    });
+  }
+
+  it('Bot 自身の発言は早期 return', async () => {
+    const controller = makeController();
+    await controller(makeMessage({ authorBot: true }));
+
+    expect(sessionManager.get).not.toHaveBeenCalled();
+    expect(rewindHandler).not.toHaveBeenCalled();
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it('スレッド外 (TextChannel 直下) のメッセージは早期 return', async () => {
+    const controller = makeController();
+    await controller(makeMessage({ channelType: ChannelType.GuildText }));
+
+    expect(sessionManager.get).not.toHaveBeenCalled();
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it('parentId が null のスレッド (通常はありえない) は早期 return', async () => {
+    const controller = makeController();
+    await controller(makeMessage({ parentId: null }));
+
+    expect(sessionManager.get).not.toHaveBeenCalled();
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it('resolvePrompt が prompt: null を返した場合は早期 return', async () => {
+    mockedResolvePrompt.mockResolvedValueOnce({ prompt: null, error: 'too large' });
+    const controller = makeController();
+    await controller(makeMessage());
+
+    expect(sessionManager.get).not.toHaveBeenCalled();
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it('PrivateThread でも処理対象', async () => {
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const controller = makeController();
+    await controller(makeMessage({ channelType: ChannelType.PrivateThread }));
+
+    expect(handleMessage).toHaveBeenCalled();
+  });
+
+  it('セッションが既にあれば tryRestore を呼ばない', async () => {
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const controller = makeController();
+    await controller(makeMessage());
+
+    expect(sessionRestorer.tryRestore).not.toHaveBeenCalled();
+    expect(ctx.setAuthorId).toHaveBeenCalledWith('user-1');
+  });
+
+  it('セッションが無ければ tryRestore で復元を試みる', async () => {
+    sessionManager.get.mockReturnValue(null);
+    const restored = makeCtx();
+    sessionRestorer.tryRestore.mockResolvedValueOnce(coerceCtx(restored));
+
+    const controller = makeController();
+    await controller(makeMessage({ channelId: 'thread-42' }));
+
+    expect(sessionRestorer.tryRestore).toHaveBeenCalledWith('thread-42', expect.anything());
+    expect(restored.setAuthorId).toHaveBeenCalledWith('user-1');
+  });
+
+  it('resolvePrompt が error を返し、ctx があれば channel.send で通知する', async () => {
+    mockedResolvePrompt.mockResolvedValueOnce({
+      prompt: 'hello',
+      error: '一部の添付ファイルを展開できませんでした',
+    });
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const msg = makeMessage();
+    const controller = makeController();
+    await controller(msg);
+
+    expect(channelSendOf(msg)).toHaveBeenCalledWith('一部の添付ファイルを展開できませんでした');
+  });
+
+  it('resolvePrompt が error を返しても ctx が null なら send しない', async () => {
+    mockedResolvePrompt.mockResolvedValueOnce({ prompt: 'hello', error: 'some error' });
+    sessionManager.get.mockReturnValue(null);
+    sessionRestorer.tryRestore.mockResolvedValueOnce(null);
+
+    const msg = makeMessage();
+    const controller = makeController();
+    await controller(msg);
+
+    expect(channelSendOf(msg)).not.toHaveBeenCalled();
+  });
+
+  it('rewindHandler が handled: true を返せば handleMessage を呼ばない', async () => {
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    rewindHandler.mockResolvedValueOnce({ handled: true });
+
+    const controller = makeController();
+    await controller(makeMessage());
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(turnStore.record).not.toHaveBeenCalled();
+  });
+
+  it('rewindHandler が handled: false なら handleMessage に委譲する', async () => {
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const controller = makeController();
+    await controller(
+      makeMessage({
+        channelId: 'thr-1',
+        messageId: 'm-99',
+        content: 'please do X',
+        authorId: 'usr-7',
+      }),
+    );
+
+    expect(handleMessage).toHaveBeenCalledWith({
+      authorBot: false,
+      authorId: 'usr-7',
+      channelId: 'parent-channel',
+      threadId: 'thr-1',
+      content: 'please do X',
+    });
+  });
+
+  it('idle → busy 遷移したときにユーザーメッセージ ID を turnStore.record に記録する', async () => {
+    const ctx = makeCtx({ sessionId: 'sess-77', state: 'idle', currentTurn: 0 });
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    handleMessage.mockImplementation(() => {
+      ctx.orchestrator.state = 'busy';
+      ctx.orchestrator.currentTurn = 3;
+    });
+
+    const controller = makeController();
+    await controller(makeMessage({ messageId: 'm-abc' }));
+    await Promise.resolve();
+
+    expect(turnStore.record).toHaveBeenCalledWith('sess-77', '/work', 3, 'm-abc');
+  });
+
+  it('状態が idle のままなら turnStore.record を呼ばない', async () => {
+    const ctx = makeCtx({ state: 'idle' });
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    handleMessage.mockImplementation(() => {
+      // state は変わらない (AccessControl で弾かれたケース等)
+    });
+
+    const controller = makeController();
+    await controller(makeMessage());
+
+    expect(turnStore.record).not.toHaveBeenCalled();
+  });
+
+  it('ctx が null のままでも handleMessage は (App 層で弾く前提で) 呼ばれ、turnStore.record は呼ばれない', async () => {
+    sessionManager.get.mockReturnValue(null);
+    sessionRestorer.tryRestore.mockResolvedValueOnce(null);
+
+    const controller = makeController();
+    await controller(makeMessage());
+
+    expect(handleMessage).toHaveBeenCalled();
+    expect(turnStore.record).not.toHaveBeenCalled();
+  });
+
+  it('添付ファイルを resolvePrompt に正しい形で渡す', async () => {
+    const attachments = new Map([
+      [
+        'a1',
+        {
+          contentType: 'text/plain',
+          name: 'notes.txt',
+          size: 100,
+          url: 'https://cdn/notes.txt',
+        },
+      ],
+    ]);
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const controller = makeController();
+    await controller(makeMessage({ content: 'body', attachments }));
+
+    expect(mockedResolvePrompt).toHaveBeenCalledWith('body', [
+      { contentType: 'text/plain', name: 'notes.txt', size: 100, url: 'https://cdn/notes.txt' },
+    ]);
+  });
+
+  it('100 文字を超える prompt はログで省略されるが正常に処理される', async () => {
+    const longContent = 'x'.repeat(250);
+    mockedResolvePrompt.mockResolvedValueOnce({ prompt: longContent, error: null });
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const controller = makeController();
+    await controller(makeMessage({ content: longContent }));
+
+    expect(handleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ content: longContent }),
+    );
+  });
+
+  it('turnStore.record が reject しても例外を伝播させない', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ctx = makeCtx({ sessionId: 'sess', state: 'idle', currentTurn: 1 });
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    turnStore.record.mockRejectedValueOnce(new Error('disk full'));
+    handleMessage.mockImplementation(() => {
+      ctx.orchestrator.state = 'busy';
+    });
+
+    const controller = makeController();
+    await expect(controller(makeMessage())).resolves.toBeUndefined();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(turnStore.record).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('channel.send が reject しても例外を伝播させない (error 通知時)', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockedResolvePrompt.mockResolvedValueOnce({ prompt: 'hi', error: 'oops' });
+    const ctx = makeCtx();
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+
+    const msg = makeMessage();
+    channelSendOf(msg).mockRejectedValueOnce(new Error('discord down'));
+
+    const controller = makeController();
+    await expect(controller(msg)).resolves.toBeUndefined();
+    await Promise.resolve();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/server/src/discord/message-controller.ts
+++ b/server/src/discord/message-controller.ts
@@ -1,0 +1,99 @@
+import { ChannelType, type Message } from 'discord.js';
+import type { MessageHandlerFn } from '../app/message-handler.js';
+import type { SessionManager } from '../domain/session-manager.js';
+import { resolvePrompt } from '../infrastructure/attachment-resolver.js';
+import type { ThreadSender } from '../infrastructure/discord-notifier.js';
+import type { SessionRestorer } from '../infrastructure/session-restorer.js';
+import type { TurnStore } from '../infrastructure/turn-store.js';
+import { log } from '../helpers.js';
+import type { RewindHandlerFn } from './rewind-handler.js';
+
+export interface MessageControllerDeps {
+  sessionManager: SessionManager;
+  sessionRestorer: SessionRestorer;
+  rewindHandler: RewindHandlerFn;
+  turnStore: TurnStore;
+  handleMessage: MessageHandlerFn;
+}
+
+export type MessageControllerFn = (msg: Message) => Promise<void>;
+
+/**
+ * Discord の MessageCreate イベントに登録するハンドラを生成する。
+ *
+ * 処理の流れ:
+ *  1. Bot 自身の発言 / スレッド外の発言を早期 return で除外
+ *  2. 添付テキストファイルをプロンプトに展開 (docs/10_Attachment_Text)
+ *  3. セッションを取得、なければディスクから遅延復元 (docs/19_Session_Persistence)
+ *  4. Bot 応答へのリプライなら巻き戻しを試行 (rewindHandler, docs/17_Conversation_Rewind)
+ *  5. 通常メッセージとして App 層 (handleMessage) に委譲
+ *  6. busy 遷移したらユーザーのメッセージ ID をターンストアに記録 (巻き戻し支援)
+ */
+export function createMessageController(deps: MessageControllerDeps): MessageControllerFn {
+  const { sessionManager, sessionRestorer, rewindHandler, turnStore, handleMessage } = deps;
+
+  return async (msg) => {
+    if (msg.author.bot) return;
+
+    if (
+      msg.channel.type !== ChannelType.PublicThread &&
+      msg.channel.type !== ChannelType.PrivateThread
+    ) {
+      return;
+    }
+
+    const parentChannelId = msg.channel.parentId;
+    if (!parentChannelId) return;
+
+    const attachments = [...msg.attachments.values()].map((a) => ({
+      contentType: a.contentType,
+      name: a.name,
+      size: a.size,
+      url: a.url,
+    }));
+    const { prompt, error } = await resolvePrompt(msg.content, attachments);
+
+    if (prompt === null) return;
+
+    log(
+      `メッセージ受信: ${msg.author.username} "${prompt.slice(0, 100)}${prompt.length > 100 ? '...' : ''}" (thread: ${msg.channelId})`,
+    );
+
+    let ctx = sessionManager.get(msg.channelId);
+    if (!ctx) {
+      ctx = await sessionRestorer.tryRestore(msg.channelId, msg.channel as ThreadSender);
+    }
+
+    if (error && ctx) {
+      msg.channel.send(error).catch((err) => console.error('Discord send error:', err));
+    }
+
+    if (ctx) {
+      ctx.setAuthorId(msg.author.id);
+    }
+
+    const rewindResult = await rewindHandler(msg, ctx, prompt);
+    if (rewindResult.handled) return;
+
+    const prevState = ctx?.orchestrator.state;
+
+    handleMessage({
+      authorBot: false,
+      authorId: msg.author.id,
+      channelId: parentChannelId,
+      threadId: msg.channelId,
+      content: prompt,
+    });
+
+    if (ctx && prevState === 'idle' && ctx.orchestrator.state === 'busy') {
+      turnStore
+        .record(ctx.session.sessionId!, ctx.session.workDir, ctx.orchestrator.currentTurn, msg.id)
+        .catch((err) => console.error('Turn record error:', err));
+    }
+
+    const newState = ctx?.orchestrator.state;
+    if (prevState !== newState) {
+      log(`状態遷移: ${prevState} → ${newState} (thread: ${msg.channelId})`);
+    }
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,8 +16,6 @@ import { Session } from './domain/session.js';
 import { SessionManager } from './domain/session-manager.js';
 import type { Workspace } from './domain/types.js';
 import { loadConfig } from './infrastructure/config.js';
-import type { ThreadSender } from './infrastructure/discord-notifier.js';
-import { resolvePrompt } from './infrastructure/attachment-resolver.js';
 import { SessionStore } from './infrastructure/session-store.js';
 import { ccCommand } from './infrastructure/slash-commands.js';
 import { TitleGenerator } from './infrastructure/title-generator.js';
@@ -33,6 +31,7 @@ import { SessionBrancher } from './infrastructure/session-brancher.js';
 import { WorkspaceStore, listDirectories } from './infrastructure/workspace-store.js';
 import { createSessionFactory, createPersistMapping } from './discord/session-factory.js';
 import { createRewindHandler } from './discord/rewind-handler.js';
+import { createMessageController } from './discord/message-controller.js';
 import {
   formatRelativeDate,
   todayJST,
@@ -107,75 +106,14 @@ async function main(): Promise<void> {
   // App 層
   const handleMessage = createMessageHandler(accessControl, sessionManager);
 
-  // メッセージイベント（スレッド内のプロンプト）
-  client.on(Events.MessageCreate, async (msg) => {
-    if (msg.author.bot) return;
-
-    if (
-      msg.channel.type !== ChannelType.PublicThread &&
-      msg.channel.type !== ChannelType.PrivateThread
-    ) {
-      return; // チャンネル直接のメッセージは無視
-    }
-
-    const parentChannelId = msg.channel.parentId;
-    if (!parentChannelId) return;
-
-    // 添付テキストファイルの解決
-    const attachments = [...msg.attachments.values()].map((a) => ({
-      contentType: a.contentType,
-      name: a.name,
-      size: a.size,
-      url: a.url,
-    }));
-    const { prompt, error } = await resolvePrompt(msg.content, attachments);
-
-    if (prompt === null) return;
-
-    log(
-      `メッセージ受信: ${msg.author.username} "${prompt.slice(0, 100)}${prompt.length > 100 ? '...' : ''}" (thread: ${msg.channelId})`,
-    );
-
-    let ctx = sessionManager.get(msg.channelId);
-
-    // セッションが見つからない場合、ディスクから遅延復元を試みる
-    if (!ctx) {
-      ctx = await sessionRestorer.tryRestore(msg.channelId, msg.channel as ThreadSender);
-    }
-
-    if (error && ctx) {
-      msg.channel.send(error).catch((err) => console.error('Discord send error:', err));
-    }
-
-    if (ctx) {
-      ctx.setAuthorId(msg.author.id);
-    }
-
-    const rewindResult = await rewindHandler(msg, ctx, prompt);
-    if (rewindResult.handled) return;
-
-    const prevState = ctx?.orchestrator.state;
-
-    handleMessage({
-      authorBot: false,
-      authorId: msg.author.id,
-      channelId: parentChannelId,
-      threadId: msg.channelId,
-      content: prompt,
-    });
-
-    // ユーザーのメッセージ ID を記録（巻き戻し用）
-    if (ctx && prevState === 'idle' && ctx.orchestrator.state === 'busy') {
-      turnStore
-        .record(ctx.session.sessionId!, ctx.session.workDir, ctx.orchestrator.currentTurn, msg.id)
-        .catch((err) => console.error('Turn record error:', err));
-    }
-
-    const newState = ctx?.orchestrator.state;
-    if (prevState !== newState) {
-      log(`状態遷移: ${prevState} → ${newState} (thread: ${msg.channelId})`);
-    }
+  const messageController = createMessageController({
+    sessionManager,
+    sessionRestorer,
+    rewindHandler,
+    turnStore,
+    handleMessage,
   });
+  client.on(Events.MessageCreate, messageController);
 
   // /cc new のワークスペース選択待ち中の options を一時保持
   const pendingNewOptions = new Map<string, import('./domain/types.js').SessionOptions>();


### PR DESCRIPTION
## Summary
- 親 issue [#16](https://github.com/manntera/chat-agent-bridge/issues/16) の Step 3
- `server/src/index.ts` の `client.on(Events.MessageCreate, ...)` ハンドラ全体 (69 行) を、高階関数 `createMessageController` として切り出し、新規ファイル `server/src/discord/message-controller.ts` に移動
- 挙動は現状維持。全 480 テスト通過 (+17 新規)、typecheck / lint / format:check / coverage / build すべて通過

Closes #19

## 背景

本 PR は、Discord 固有コードを `discord/` 配下に再配置するリファクタリング (親 issue #16) の第 3 段階です。`MessageCreate` ハンドラは以下 9 ステップを 1 つのアロー関数に直書きしていました。

1. Bot 自身の発言 / スレッド外の発言を除外
2. 添付テキストファイルをプロンプトに展開 (`docs/10_Attachment_Text`)
3. セッション取得 / 遅延復元 (`docs/19_Session_Persistence`)
4. 質問者 ID を Notifier に記録 (メンション付与、`docs/16_Reply_Mention`)
5. リプライによる巻き戻し試行 (Step 2 で分離済みの `rewindHandler` を呼ぶ)
6. 通常メッセージとして App 層 (`handleMessage`) に委譲
7. busy 遷移時にユーザーメッセージ ID を `turnStore` に記録
8. 状態遷移ログ出力

Step 2 で `rewindHandler` を分離したことにより、本 Step ではそれを呼ぶだけで済む形になりました。

## 変更内容

### 新規ファイル
- `server/src/discord/message-controller.ts` — `createMessageController` / `MessageControllerFn` / `MessageControllerDeps` をエクスポート
- `server/src/discord/message-controller.test.ts` — ユニットテスト 17 件

### `createMessageController` の設計
依存 (`sessionManager`, `sessionRestorer`, `rewindHandler`, `turnStore`, `handleMessage`) をファクトリ引数で受け、`(msg: Message) => Promise<void>` を返す高階関数。`rewindHandler` は Step 2 で公開した `RewindHandlerFn` 型をそのまま受け入れる形にし、型の単一源を維持。

ハンドラ内部のロジックは原則「そのまま移動」で、本 Step での挙動変更はなし。

### `index.ts` への影響
- 110-178 行目 (69 行) の `MessageCreate` ハンドラ本体を削除
- DI 部に 7 行を追加 (`createMessageController({...})` と `client.on(Events.MessageCreate, messageController)`)
- 不要になった import (`ChannelType` は他箇所で継続使用のため残留 / `resolvePrompt` / `ThreadSender`) を削除
- ファイル行数: 832 → 770 行 (-62 行)

## テスト

### 既存テスト
- 29 ファイル、462 → 479 件すべて通過 (+17 新規)
- 既存の統合テストにも影響なし

### 新規テスト (`message-controller.test.ts`) の主要シナリオ
- Bot 自身の発言 → 早期 return
- スレッド外 (`GuildText`) のメッセージ → 早期 return
- `parentId` null のスレッド (通常ありえない) → 早期 return
- `resolvePrompt` が `prompt: null` を返したケース → 早期 return
- `PrivateThread` も処理対象に含まれる
- セッション存在 → `sessionRestorer.tryRestore` は呼ばれない
- セッション不在 → `sessionRestorer.tryRestore` で復元を試みる
- `resolvePrompt` が error を返し ctx あり → `msg.channel.send(error)`
- error あっても ctx なし → send しない
- `rewindHandler` が `handled: true` → `handleMessage` も `turnStore.record` も呼ばれない
- `rewindHandler` が `handled: false` → `handleMessage` に正しい `DiscordMessage` を渡す
- `idle` → `busy` 遷移 → `turnStore.record(sessionId, workDir, currentTurn, msgId)` 呼び出し
- 状態変化なし (`idle` のまま) → `turnStore.record` 呼ばれない
- `ctx` null でも `handleMessage` 自体は呼ばれる (App 層で弾く前提)
- 添付ファイルあり → `resolvePrompt` に配列化して渡される
- `turnStore.record` が reject → 例外伝播しない (`console.error` のみ)
- `msg.channel.send` が reject → 例外伝播しない
- 長い prompt (>100 文字) → 正常に処理される (ログ省略分岐のカバー)

### カバレッジ
- `message-controller.ts`: Stmts 100% / Branch 100% / Lines 100% / Funcs 100%

## 検証手順
```sh
cd server
pnpm install
pnpm run check       # typecheck + lint + format:check + test
pnpm run test:coverage
pnpm run build
```

## 注意事項
- Discord 上での実機動作確認 (通常メッセージ送信 / 添付ファイル / スレッド再起動後の遅延復元 / 巻き戻しの end-to-end) はローカル環境の制約により本 PR では未実施です。マージ前に手動確認をお願いします。
- 本 PR で解放される後続作業: #25 Step 6 のうち、`MessageCreate` 系の Composition Root 化要素。`InteractionCreate` 系 (#20〜#24) は本 Step と独立しており、順序入れ替えは可能。
