### PR TITLE
refactor: /cc interrupt を commands/interrupt.ts に分離 (#21)

### DIFF
--- a/server/src/discord/commands/interrupt.test.ts
+++ b/server/src/discord/commands/interrupt.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChannelType, type ChatInputCommandInteraction } from 'discord.js';
+import type { SessionContext, SessionManager } from '../../domain/session-manager.js';
+import type { Command, OrchestratorState } from '../../domain/types.js';
+import { createInterruptCommand } from './interrupt.js';
+
+interface CtxStub {
+  orchestrator: {
+    state: OrchestratorState;
+    handleCommand: ReturnType<typeof vi.fn>;
+  };
+}
+
+interface InteractionStub {
+  channel: { type: ChannelType } | null;
+  channelId: string;
+  reply: ReturnType<typeof vi.fn>;
+}
+
+function makeCtx(state: OrchestratorState = 'idle'): CtxStub {
+  return {
+    orchestrator: { state, handleCommand: vi.fn() },
+  };
+}
+
+function makeInteraction(
+  options: {
+    channelType?: ChannelType | null;
+    channelId?: string;
+  } = {},
+): InteractionStub {
+  const { channelType = ChannelType.PublicThread, channelId = 'thread-1' } = options;
+  return {
+    channel: channelType === null ? null : { type: channelType },
+    channelId,
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function coerceCtx(c: CtxStub): SessionContext {
+  return c as unknown as SessionContext;
+}
+
+function coerceInteraction(i: InteractionStub): ChatInputCommandInteraction {
+  return i as unknown as ChatInputCommandInteraction;
+}
+
+describe('createInterruptCommand', () => {
+  let sessionManager: { get: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionManager = { get: vi.fn().mockReturnValue(null) };
+  });
+
+  function makeHandler() {
+    return createInterruptCommand({
+      sessionManager: sessionManager as unknown as SessionManager,
+    });
+  }
+
+  it('スレッド外で実行された場合は拒否メッセージを返し、セッションを検索しない', async () => {
+    const handler = makeHandler();
+    const interaction = makeInteraction({ channelType: ChannelType.GuildText });
+
+    await handler(coerceInteraction(interaction));
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'セッションスレッド内で実行してください',
+      ephemeral: true,
+    });
+    expect(sessionManager.get).not.toHaveBeenCalled();
+  });
+
+  it('スレッド内でもセッションが紐づいていなければ拒否メッセージを返す', async () => {
+    const handler = makeHandler();
+    sessionManager.get.mockReturnValue(null);
+    const interaction = makeInteraction({ channelId: 'thread-42' });
+
+    await handler(coerceInteraction(interaction));
+
+    expect(sessionManager.get).toHaveBeenCalledWith('thread-42');
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'このスレッドにはセッションが紐づいていません',
+      ephemeral: true,
+    });
+  });
+
+  it('busy 状態なら interrupt コマンドを発行し「✅」を返す', async () => {
+    const ctx = makeCtx('busy');
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    const handler = makeHandler();
+    const interaction = makeInteraction();
+
+    await handler(coerceInteraction(interaction));
+
+    expect(ctx.orchestrator.handleCommand).toHaveBeenCalledWith({
+      type: 'interrupt',
+    } satisfies Command);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: '✅', ephemeral: true });
+  });
+
+  it('interrupting 状態なら「既に中断処理中です」を返し、コマンドは発行しない', async () => {
+    const ctx = makeCtx('interrupting');
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    const handler = makeHandler();
+    const interaction = makeInteraction();
+
+    await handler(coerceInteraction(interaction));
+
+    expect(ctx.orchestrator.handleCommand).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: '既に中断処理中です',
+      ephemeral: true,
+    });
+  });
+
+  it('idle 状態なら「処理中ではありません」を返し、コマンドは発行しない', async () => {
+    const ctx = makeCtx('idle');
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    const handler = makeHandler();
+    const interaction = makeInteraction();
+
+    await handler(coerceInteraction(interaction));
+
+    expect(ctx.orchestrator.handleCommand).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: '処理中ではありません',
+      ephemeral: true,
+    });
+  });
+});

--- a/server/src/discord/commands/interrupt.test.ts
+++ b/server/src/discord/commands/interrupt.test.ts
@@ -129,4 +129,19 @@ describe('createInterruptCommand', () => {
       ephemeral: true,
     });
   });
+
+  it('initial 状態なら「処理中ではありません」を返し、コマンドは発行しない (OrchestratorState 初期値の網羅)', async () => {
+    const ctx = makeCtx('initial');
+    sessionManager.get.mockReturnValue(coerceCtx(ctx));
+    const handler = makeHandler();
+    const interaction = makeInteraction();
+
+    await handler(coerceInteraction(interaction));
+
+    expect(ctx.orchestrator.handleCommand).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: '処理中ではありません',
+      ephemeral: true,
+    });
+  });
 });

--- a/server/src/discord/commands/interrupt.ts
+++ b/server/src/discord/commands/interrupt.ts
@@ -1,0 +1,51 @@
+import { ChannelType, type ChatInputCommandInteraction } from 'discord.js';
+import type { SessionManager } from '../../domain/session-manager.js';
+
+export interface InterruptCommandDeps {
+  sessionManager: SessionManager;
+}
+
+export type InterruptCommandFn = (interaction: ChatInputCommandInteraction) => Promise<void>;
+
+/**
+ * `/cc interrupt` サブコマンドのハンドラを生成する。
+ *
+ * 処理中 (`busy`) の Claude プロセスに中断コマンドを送り、SIGINT → 10 秒待機 → SIGKILL の
+ * フローを起動する。スレッド外では拒否し、対象スレッドにセッションが紐づいていなければ
+ * 拒否メッセージを返す。詳細は docs/07_PoC_Improvements.md を参照。
+ */
+export function createInterruptCommand(deps: InterruptCommandDeps): InterruptCommandFn {
+  const { sessionManager } = deps;
+
+  return async (interaction) => {
+    const isThread =
+      interaction.channel?.type === ChannelType.PublicThread ||
+      interaction.channel?.type === ChannelType.PrivateThread;
+
+    if (!isThread) {
+      await interaction.reply({
+        content: 'セッションスレッド内で実行してください',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const ctx = sessionManager.get(interaction.channelId);
+    if (!ctx) {
+      await interaction.reply({
+        content: 'このスレッドにはセッションが紐づいていません',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    if (ctx.orchestrator.state === 'busy') {
+      ctx.orchestrator.handleCommand({ type: 'interrupt' });
+      await interaction.reply({ content: '✅', ephemeral: true });
+    } else if (ctx.orchestrator.state === 'interrupting') {
+      await interaction.reply({ content: '既に中断処理中です', ephemeral: true });
+    } else {
+      await interaction.reply({ content: '処理中ではありません', ephemeral: true });
+    }
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import { WorkspaceStore, listDirectories } from './infrastructure/workspace-stor
 import { createSessionFactory, createPersistMapping } from './discord/session-factory.js';
 import { createRewindHandler } from './discord/rewind-handler.js';
 import { createMessageController } from './discord/message-controller.js';
+import { createInterruptCommand } from './discord/commands/interrupt.js';
 import {
   formatRelativeDate,
   todayJST,
@@ -114,6 +115,8 @@ async function main(): Promise<void> {
     handleMessage,
   });
   client.on(Events.MessageCreate, messageController);
+
+  const interruptCommand = createInterruptCommand({ sessionManager });
 
   // /cc new のワークスペース選択待ち中の options を一時保持
   const pendingNewOptions = new Map<string, import('./domain/types.js').SessionOptions>();
@@ -542,35 +545,7 @@ async function main(): Promise<void> {
 
     // /cc interrupt — スレッド内で実行した場合のみ処理
     if (subcommand === 'interrupt') {
-      const isThread =
-        interaction.channel?.type === ChannelType.PublicThread ||
-        interaction.channel?.type === ChannelType.PrivateThread;
-
-      if (!isThread) {
-        await interaction.reply({
-          content: 'セッションスレッド内で実行してください',
-          ephemeral: true,
-        });
-        return;
-      }
-
-      const ctx = sessionManager.get(interaction.channelId);
-      if (!ctx) {
-        await interaction.reply({
-          content: 'このスレッドにはセッションが紐づいていません',
-          ephemeral: true,
-        });
-        return;
-      }
-
-      if (ctx.orchestrator.state === 'busy') {
-        ctx.orchestrator.handleCommand({ type: 'interrupt' });
-        await interaction.reply({ content: '✅', ephemeral: true });
-      } else if (ctx.orchestrator.state === 'interrupting') {
-        await interaction.reply({ content: '既に中断処理中です', ephemeral: true });
-      } else {
-        await interaction.reply({ content: '処理中ではありません', ephemeral: true });
-      }
+      await interruptCommand(interaction);
       return;
     }
 


### PR DESCRIPTION
## Summary

- `/cc interrupt` ハンドラを `server/src/discord/commands/interrupt.ts` に分離
- Step 5 系の最小テンプレートとして以降の Step 5b/5c/5d の雛形

## 背景

親 issue #16 のリファクタリングの一環。`server/src/index.ts` を責務別に分割し Discord 固有コードを `discord/` 配下に整理する。`/cc interrupt` は最もシンプル(約 30 行)で、Step 5 系の「最小テンプレート」として先に抽出する。

## 変更内容

- **新規**: `server/src/discord/commands/interrupt.ts` — `createInterruptCommand` ファクトリ
- **新規**: `server/src/discord/commands/interrupt.test.ts` — 5 ケース
- **`server/src/index.ts`**:
  - 543-575 行の `/cc interrupt` 処理を削除(元 issue 記載は 725-756 行だが、Step 1〜3 の抽出が先行マージ済みのため現在位置は 543-575 行)
  - 冒頭に `createInterruptCommand` の import 追加
  - `main()` 内で `createInterruptCommand({ sessionManager })` を構築
  - `InteractionCreate` 内で `subcommand === 'interrupt'` 時に呼び出し

## テスト

- 新規 5 件、合計 485 件通過
- `interrupt.ts` カバレッジ: Stmt 100% / Branch 100% / Func 100% / Line 100%

## 検証手順

```
cd server && pnpm install
pnpm run check
pnpm run test:coverage
pnpm run build
```

## 注意事項

- Discord 実機での `/cc interrupt` 動作確認は未実施。後続でまとめて検証予定。

Closes #21
