### PR TITLE
refactor: /cc workspace を commands/workspace.ts に分離 (#20)

### DIFF
--- a/server/src/discord/commands/workspace.test.ts
+++ b/server/src/discord/commands/workspace.test.ts
@@ -1,0 +1,428 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChatInputCommandInteraction, StringSelectMenuInteraction } from 'discord.js';
+import type { WorkspaceStore } from '../../infrastructure/workspace-store.js';
+import { createWorkspaceCommands } from './workspace.js';
+
+// listDirectories をモック化してファイルシステムに依存しない
+vi.mock('../../infrastructure/workspace-store.js', async () => {
+  const actual = await vi.importActual<typeof import('../../infrastructure/workspace-store.js')>(
+    '../../infrastructure/workspace-store.js',
+  );
+  return {
+    ...actual,
+    listDirectories: vi.fn<(dirPath: string) => string[]>().mockReturnValue([]),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const workspaceStoreModule: any = await import('../../infrastructure/workspace-store.js');
+const mockedListDirectories = workspaceStoreModule.listDirectories as ReturnType<typeof vi.fn>;
+
+interface WorkspaceStoreMock {
+  list: ReturnType<typeof vi.fn>;
+  add: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  findByName: ReturnType<typeof vi.fn>;
+}
+
+function makeWorkspaceStore(): WorkspaceStoreMock {
+  return {
+    list: vi.fn().mockReturnValue([]),
+    add: vi.fn(),
+    remove: vi.fn().mockReturnValue(false),
+    findByName: vi.fn().mockReturnValue(undefined),
+  };
+}
+
+function coerceStore(s: WorkspaceStoreMock): WorkspaceStore {
+  return s as unknown as WorkspaceStore;
+}
+
+interface ChatInputStubOptions {
+  userId?: string;
+  subcommand: 'add' | 'remove' | 'list';
+  /** add: name option, remove: name option */
+  name?: string | null;
+  /** add: path option */
+  path?: string | null;
+  /** remove 時 `getString('name', true)` で null を返したい特殊ケース */
+}
+
+function makeChatInput(opts: ChatInputStubOptions): {
+  interaction: ChatInputCommandInteraction;
+  reply: ReturnType<typeof vi.fn>;
+} {
+  const { userId = 'user-1', subcommand, name = null, path = null } = opts;
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const getString = vi.fn((key: string): string | null => {
+    if (key === 'name') return name;
+    if (key === 'path') return path;
+    return null;
+  });
+  const interaction = {
+    user: { id: userId },
+    reply,
+    options: {
+      getSubcommand: () => subcommand,
+      getString,
+    },
+  } as unknown as ChatInputCommandInteraction;
+  return { interaction, reply };
+}
+
+interface SelectMenuStubOptions {
+  userId?: string;
+  value: string;
+}
+
+function makeSelectMenu(opts: SelectMenuStubOptions): {
+  interaction: StringSelectMenuInteraction;
+  update: ReturnType<typeof vi.fn>;
+} {
+  const { userId = 'user-1', value } = opts;
+  const update = vi.fn().mockResolvedValue(undefined);
+  const interaction = {
+    user: { id: userId },
+    values: [value],
+    update,
+  } as unknown as StringSelectMenuInteraction;
+  return { interaction, update };
+}
+
+describe('createWorkspaceCommands', () => {
+  let workspaceStore: WorkspaceStoreMock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workspaceStore = makeWorkspaceStore();
+    mockedListDirectories.mockReturnValue([]);
+  });
+
+  function make() {
+    return createWorkspaceCommands({
+      workspaceStore: coerceStore(workspaceStore),
+      workspaceBaseDir: '/base',
+    });
+  }
+
+  it('browseCustomId は "cc_workspace_browse"', () => {
+    const cmds = make();
+    expect(cmds.browseCustomId).toBe('cc_workspace_browse');
+  });
+
+  describe('handleCommand — /cc workspace add', () => {
+    it('name と path 指定 → workspaceStore.add が呼ばれ、成功メッセージを返す', async () => {
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: 'my-ws',
+        path: '/home/user/project',
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(workspaceStore.add).toHaveBeenCalledWith({
+        name: 'my-ws',
+        path: '/home/user/project',
+      });
+      expect(reply).toHaveBeenCalledWith({
+        content: '✅ ワークスペース「my-ws」を登録しました (/home/user/project)',
+        ephemeral: true,
+      });
+    });
+
+    it('path のみ指定 (name 省略) → basename(path) を name として登録する', async () => {
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: null,
+        path: '/home/user/auto-named',
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(workspaceStore.add).toHaveBeenCalledWith({
+        name: 'auto-named',
+        path: '/home/user/auto-named',
+      });
+      expect(reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('auto-named'),
+          ephemeral: true,
+        }),
+      );
+    });
+
+    it('path 指定時に workspaceStore.add が例外を投げたら警告メッセージを返す', async () => {
+      workspaceStore.add.mockImplementation(() => {
+        throw new Error('既に登録されています');
+      });
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: 'dup',
+        path: '/tmp/dup',
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(reply).toHaveBeenCalledWith({
+        content: '⚠️ 既に登録されています',
+        ephemeral: true,
+      });
+    });
+
+    it('path 指定時の add 例外が Error でなくても汎用メッセージにフォールバックする', async () => {
+      workspaceStore.add.mockImplementation(() => {
+        throw 'string error';
+      });
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: 'x',
+        path: '/tmp/x',
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(reply).toHaveBeenCalledWith({
+        content: '⚠️ 登録に失敗しました',
+        ephemeral: true,
+      });
+    });
+
+    it('path 省略 → ブラウズ UI セレクトメニュー付きで reply する', async () => {
+      mockedListDirectories.mockReturnValue(['projectA', 'projectB']);
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: 'custom-name',
+        path: null,
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(workspaceStore.add).not.toHaveBeenCalled();
+      expect(reply).toHaveBeenCalledTimes(1);
+      const call = reply.mock.calls[0][0];
+      expect(call.content).toBe('📂 /base');
+      expect(call.ephemeral).toBe(true);
+      expect(Array.isArray(call.components)).toBe(true);
+      expect(call.components).toHaveLength(1);
+    });
+  });
+
+  describe('handleCommand — /cc workspace remove', () => {
+    it('存在する name → 成功メッセージ', async () => {
+      workspaceStore.remove.mockReturnValue(true);
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'remove',
+        name: 'target',
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(workspaceStore.remove).toHaveBeenCalledWith('target');
+      expect(reply).toHaveBeenCalledWith({
+        content: '✅ ワークスペース「target」を削除しました',
+        ephemeral: true,
+      });
+    });
+
+    it('存在しない name → 警告メッセージ', async () => {
+      workspaceStore.remove.mockReturnValue(false);
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'remove',
+        name: 'missing',
+      });
+
+      await cmds.handleCommand(interaction);
+
+      expect(reply).toHaveBeenCalledWith({
+        content: '⚠️ ワークスペース「missing」が見つかりません',
+        ephemeral: true,
+      });
+    });
+  });
+
+  describe('handleCommand — /cc workspace list', () => {
+    it('0 件 → 登録促しメッセージ', async () => {
+      workspaceStore.list.mockReturnValue([]);
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({ subcommand: 'list' });
+
+      await cmds.handleCommand(interaction);
+
+      expect(reply).toHaveBeenCalledWith({
+        content: 'ワークスペースが登録されていません。`/cc workspace add` で登録してください。',
+        ephemeral: true,
+      });
+    });
+
+    it('複数件 → 連番付きの一覧メッセージ', async () => {
+      workspaceStore.list.mockReturnValue([
+        { name: 'alpha', path: '/a' },
+        { name: 'beta', path: '/b' },
+      ]);
+      const cmds = make();
+      const { interaction, reply } = makeChatInput({ subcommand: 'list' });
+
+      await cmds.handleCommand(interaction);
+
+      expect(reply).toHaveBeenCalledWith({
+        content: '📁 登録済みワークスペース:\n1. **alpha** — /a\n2. **beta** — /b',
+        ephemeral: true,
+      });
+    });
+  });
+
+  describe('handleBrowseSelect', () => {
+    it('ブラウズ state が無い (期限切れ) → エラーメッセージを update', async () => {
+      const cmds = make();
+      const { interaction, update } = makeSelectMenu({ value: '__confirm__' });
+
+      await cmds.handleBrowseSelect(interaction);
+
+      expect(update).toHaveBeenCalledWith({
+        content: 'ブラウズセッションが期限切れです。再度 `/cc workspace add` を実行してください。',
+        components: [],
+      });
+      expect(workspaceStore.add).not.toHaveBeenCalled();
+    });
+
+    it('__confirm__ 選択 → customName があればそれを、無ければ basename を name として登録', async () => {
+      const cmds = make();
+
+      // まず add コマンドで state を仕込む
+      const { interaction: addI } = makeChatInput({
+        subcommand: 'add',
+        name: 'override-name',
+        path: null,
+      });
+      await cmds.handleCommand(addI);
+
+      const { interaction: selI, update } = makeSelectMenu({ value: '__confirm__' });
+      await cmds.handleBrowseSelect(selI);
+
+      expect(workspaceStore.add).toHaveBeenCalledWith({
+        name: 'override-name',
+        path: '/base',
+      });
+      expect(update).toHaveBeenCalledWith({
+        content: '✅ ワークスペース「override-name」を登録しました (/base)',
+        components: [],
+      });
+    });
+
+    it('__confirm__ 選択時に workspaceStore.add が例外を投げたら警告 update', async () => {
+      workspaceStore.add.mockImplementation(() => {
+        throw new Error('duplicate');
+      });
+      const cmds = make();
+      const { interaction: addI } = makeChatInput({
+        subcommand: 'add',
+        name: null,
+        path: null,
+      });
+      await cmds.handleCommand(addI);
+
+      const { interaction: selI, update } = makeSelectMenu({ value: '__confirm__' });
+      await cmds.handleBrowseSelect(selI);
+
+      expect(update).toHaveBeenCalledWith({
+        content: '⚠️ duplicate',
+        components: [],
+      });
+    });
+
+    it('__up__ 選択 → 親ディレクトリへ遷移したメニューを update', async () => {
+      mockedListDirectories.mockReturnValue(['sub']);
+      const cmds = createWorkspaceCommands({
+        workspaceStore: coerceStore(workspaceStore),
+        workspaceBaseDir: '/home/user/project',
+      });
+
+      // state を仕込む
+      const { interaction: addI } = makeChatInput({
+        subcommand: 'add',
+        name: null,
+        path: null,
+      });
+      await cmds.handleCommand(addI);
+
+      const { interaction: selI, update } = makeSelectMenu({ value: '__up__' });
+      await cmds.handleBrowseSelect(selI);
+
+      expect(update).toHaveBeenCalledWith({
+        content: '📂 /home/user',
+        components: expect.any(Array),
+      });
+    });
+
+    it('サブディレクトリ選択 → そのディレクトリに降りたメニューを update', async () => {
+      mockedListDirectories.mockReturnValue(['foo', 'bar']);
+      const cmds = make();
+
+      const { interaction: addI } = makeChatInput({
+        subcommand: 'add',
+        name: null,
+        path: null,
+      });
+      await cmds.handleCommand(addI);
+
+      const { interaction: selI, update } = makeSelectMenu({ value: 'foo' });
+      await cmds.handleBrowseSelect(selI);
+
+      expect(update).toHaveBeenCalledWith({
+        content: '📂 /base/foo',
+        components: expect.any(Array),
+      });
+    });
+  });
+
+  describe('ブラウズメニュー構築の詳細', () => {
+    it('listDirectories が 23 件超返しても 23 件までしかオプションに含めない', async () => {
+      const manyDirs = Array.from({ length: 30 }, (_, i) => `dir${i}`);
+      mockedListDirectories.mockReturnValue(manyDirs);
+      const cmds = make();
+
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: null,
+        path: null,
+      });
+      await cmds.handleCommand(interaction);
+
+      // row は components 配列の先頭、そこから options を取り出す
+      const call = reply.mock.calls[0][0];
+      const row = call.components[0];
+      const selectMenu = row.components[0];
+      // __confirm__ + __up__ + 23 サブディレクトリ = 最大 25 件
+      expect(selectMenu.options.length).toBeLessThanOrEqual(25);
+      expect(selectMenu.options.length).toBeGreaterThanOrEqual(24);
+    });
+
+    it('ルートディレクトリ (/) でブラウズ開始時は __up__ オプションを含まない', async () => {
+      mockedListDirectories.mockReturnValue(['etc']);
+      const cmds = createWorkspaceCommands({
+        workspaceStore: coerceStore(workspaceStore),
+        workspaceBaseDir: '/',
+      });
+
+      const { interaction, reply } = makeChatInput({
+        subcommand: 'add',
+        name: null,
+        path: null,
+      });
+      await cmds.handleCommand(interaction);
+
+      const call = reply.mock.calls[0][0];
+      const selectMenu = call.components[0].components[0];
+      const values = selectMenu.options.map((o: { data: { value: string } }) => o.data.value);
+      expect(values).toContain('__confirm__');
+      expect(values).not.toContain('__up__');
+    });
+  });
+});

--- a/server/src/discord/commands/workspace.test.ts
+++ b/server/src/discord/commands/workspace.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChatInputCommandInteraction, StringSelectMenuInteraction } from 'discord.js';
-import type { WorkspaceStore } from '../../infrastructure/workspace-store.js';
+import { listDirectories, type WorkspaceStore } from '../../infrastructure/workspace-store.js';
 import { createWorkspaceCommands } from './workspace.js';
 
 // listDirectories をモック化してファイルシステムに依存しない
@@ -14,9 +14,7 @@ vi.mock('../../infrastructure/workspace-store.js', async () => {
   };
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const workspaceStoreModule: any = await import('../../infrastructure/workspace-store.js');
-const mockedListDirectories = workspaceStoreModule.listDirectories as ReturnType<typeof vi.fn>;
+const mockedListDirectories = vi.mocked(listDirectories);
 
 interface WorkspaceStoreMock {
   list: ReturnType<typeof vi.fn>;

--- a/server/src/discord/commands/workspace.ts
+++ b/server/src/discord/commands/workspace.ts
@@ -1,0 +1,214 @@
+import { basename, dirname, join } from 'node:path';
+import {
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  type ChatInputCommandInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+import type { WorkspaceStore } from '../../infrastructure/workspace-store.js';
+import { listDirectories } from '../../infrastructure/workspace-store.js';
+
+const BROWSE_CUSTOM_ID = 'cc_workspace_browse';
+
+export interface WorkspaceCommandsDeps {
+  workspaceStore: WorkspaceStore;
+  workspaceBaseDir: string;
+}
+
+export interface WorkspaceCommands {
+  browseCustomId: string;
+  handleCommand: (interaction: ChatInputCommandInteraction) => Promise<void>;
+  handleBrowseSelect: (interaction: StringSelectMenuInteraction) => Promise<void>;
+}
+
+/**
+ * `/cc workspace add/remove/list` サブコマンドと `cc_workspace_browse` セレクトメニューの
+ * ハンドラを生成する。ディレクトリブラウズ中のユーザー状態 (`browsingState`) はこの
+ * ファクトリの module-level クロージャに閉じ、外部に漏らさない。
+ *
+ * - `handleCommand(interaction)` — `/cc workspace add/remove/list` を処理
+ * - `handleBrowseSelect(interaction)` — `cc_workspace_browse` セレクトの選択を処理
+ * - `browseCustomId` — ディスパッチ側で customId 判定に使うための公開定数
+ */
+export function createWorkspaceCommands(deps: WorkspaceCommandsDeps): WorkspaceCommands {
+  const { workspaceStore, workspaceBaseDir } = deps;
+
+  // /cc workspace add のディレクトリブラウズ状態を一時保持
+  const browsingState = new Map<string, { currentPath: string; customName?: string }>();
+
+  /** ディレクトリブラウズ用のセレクトメニューを構築する */
+  function buildBrowseMenu(currentPath: string): ActionRowBuilder<StringSelectMenuBuilder> | null {
+    const dirs = listDirectories(currentPath);
+    const options: Array<{ label: string; description: string; value: string }> = [];
+
+    // 現在のディレクトリを登録する選択肢
+    options.push({
+      label: `${basename(currentPath)} をワークスペースに登録`,
+      description: currentPath,
+      value: '__confirm__',
+    });
+
+    // 上のディレクトリへ（ルートでない場合）
+    if (dirname(currentPath) !== currentPath) {
+      options.push({
+        label: '.. (上のディレクトリへ)',
+        description: dirname(currentPath),
+        value: '__up__',
+      });
+    }
+
+    // サブディレクトリ（最大23件 — confirm + up で2枠使用、合計25が上限）
+    for (const dir of dirs.slice(0, 23)) {
+      const fullPath = join(currentPath, dir);
+      options.push({
+        label: dir,
+        description: fullPath.length > 100 ? '...' + fullPath.slice(-97) : fullPath,
+        value: dir,
+      });
+    }
+
+    const selectMenu = new StringSelectMenuBuilder()
+      .setCustomId(BROWSE_CUSTOM_ID)
+      .setPlaceholder('ディレクトリを選択してください')
+      .addOptions(options);
+
+    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
+  }
+
+  async function handleCommand(interaction: ChatInputCommandInteraction): Promise<void> {
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'add') {
+      const name = interaction.options.getString('name') ?? undefined;
+      const path = interaction.options.getString('path') ?? undefined;
+
+      // path が指定されている場合は直接登録
+      if (path) {
+        const wsName = name || basename(path);
+        try {
+          workspaceStore.add({ name: wsName, path });
+          await interaction.reply({
+            content: `✅ ワークスペース「${wsName}」を登録しました (${path})`,
+            ephemeral: true,
+          });
+        } catch (err) {
+          await interaction.reply({
+            content: `⚠️ ${err instanceof Error ? err.message : '登録に失敗しました'}`,
+            ephemeral: true,
+          });
+        }
+        return;
+      }
+
+      // path 省略 → ディレクトリブラウズモード
+      const startPath = workspaceBaseDir;
+      browsingState.set(interaction.user.id, { currentPath: startPath, customName: name });
+
+      const row = buildBrowseMenu(startPath);
+      if (row) {
+        await interaction.reply({
+          content: `📂 ${startPath}`,
+          components: [row],
+          ephemeral: true,
+        });
+      } else {
+        await interaction.reply({
+          content: '⚠️ ベースディレクトリの読み取りに失敗しました',
+          ephemeral: true,
+        });
+      }
+      return;
+    }
+
+    if (subcommand === 'remove') {
+      const name = interaction.options.getString('name', true);
+      const removed = workspaceStore.remove(name);
+      if (removed) {
+        await interaction.reply({
+          content: `✅ ワークスペース「${name}」を削除しました`,
+          ephemeral: true,
+        });
+      } else {
+        await interaction.reply({
+          content: `⚠️ ワークスペース「${name}」が見つかりません`,
+          ephemeral: true,
+        });
+      }
+      return;
+    }
+
+    if (subcommand === 'list') {
+      const workspaces = workspaceStore.list();
+      if (workspaces.length === 0) {
+        await interaction.reply({
+          content: 'ワークスペースが登録されていません。`/cc workspace add` で登録してください。',
+          ephemeral: true,
+        });
+      } else {
+        const lines = workspaces.map((w, i) => `${i + 1}. **${w.name}** — ${w.path}`);
+        await interaction.reply({
+          content: `📁 登録済みワークスペース:\n${lines.join('\n')}`,
+          ephemeral: true,
+        });
+      }
+      return;
+    }
+  }
+
+  async function handleBrowseSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+    const selected = interaction.values[0];
+    const state = browsingState.get(interaction.user.id);
+
+    if (!state) {
+      await interaction.update({
+        content: 'ブラウズセッションが期限切れです。再度 `/cc workspace add` を実行してください。',
+        components: [],
+      });
+      return;
+    }
+
+    if (selected === '__confirm__') {
+      // 現在のディレクトリをワークスペースとして登録
+      const wsName = state.customName || basename(state.currentPath);
+      browsingState.delete(interaction.user.id);
+      try {
+        workspaceStore.add({ name: wsName, path: state.currentPath });
+        await interaction.update({
+          content: `✅ ワークスペース「${wsName}」を登録しました (${state.currentPath})`,
+          components: [],
+        });
+      } catch (err) {
+        await interaction.update({
+          content: `⚠️ ${err instanceof Error ? err.message : '登録に失敗しました'}`,
+          components: [],
+        });
+      }
+      return;
+    }
+
+    if (selected === '__up__') {
+      state.currentPath = dirname(state.currentPath);
+    } else {
+      state.currentPath = join(state.currentPath, selected);
+    }
+
+    const row = buildBrowseMenu(state.currentPath);
+    if (row) {
+      await interaction.update({
+        content: `📂 ${state.currentPath}`,
+        components: [row],
+      });
+    } else {
+      await interaction.update({
+        content: `⚠️ ディレクトリの読み取りに失敗しました`,
+        components: [],
+      });
+    }
+  }
+
+  return {
+    browseCustomId: BROWSE_CUSTOM_ID,
+    handleCommand,
+    handleBrowseSelect,
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { basename, dirname, join } from 'node:path';
 import {
   ActionRowBuilder,
   Client,
@@ -28,10 +27,11 @@ import { SessionRestorer } from './infrastructure/session-restorer.js';
 import { ThreadMappingStore } from './infrastructure/thread-mapping-store.js';
 import { TurnStore } from './infrastructure/turn-store.js';
 import { SessionBrancher } from './infrastructure/session-brancher.js';
-import { WorkspaceStore, listDirectories } from './infrastructure/workspace-store.js';
+import { WorkspaceStore } from './infrastructure/workspace-store.js';
 import { createSessionFactory, createPersistMapping } from './discord/session-factory.js';
 import { createRewindHandler } from './discord/rewind-handler.js';
 import { createMessageController } from './discord/message-controller.js';
+import { createWorkspaceCommands } from './discord/commands/workspace.js';
 import {
   formatRelativeDate,
   todayJST,
@@ -118,47 +118,10 @@ async function main(): Promise<void> {
   // /cc new のワークスペース選択待ち中の options を一時保持
   const pendingNewOptions = new Map<string, import('./domain/types.js').SessionOptions>();
 
-  // /cc workspace add のディレクトリブラウズ状態を一時保持
-  const browsingState = new Map<string, { currentPath: string; customName?: string }>();
-
-  /** ディレクトリブラウズ用のセレクトメニューを構築する */
-  function buildBrowseMenu(currentPath: string): ActionRowBuilder<StringSelectMenuBuilder> | null {
-    const dirs = listDirectories(currentPath);
-    const options: Array<{ label: string; description: string; value: string }> = [];
-
-    // 現在のディレクトリを登録する選択肢
-    options.push({
-      label: `${basename(currentPath)} をワークスペースに登録`,
-      description: currentPath,
-      value: '__confirm__',
-    });
-
-    // 上のディレクトリへ（ルートでない場合）
-    if (dirname(currentPath) !== currentPath) {
-      options.push({
-        label: '.. (上のディレクトリへ)',
-        description: dirname(currentPath),
-        value: '__up__',
-      });
-    }
-
-    // サブディレクトリ（最大23件 — confirm + up で2枠使用、合計25が上限）
-    for (const dir of dirs.slice(0, 23)) {
-      const fullPath = join(currentPath, dir);
-      options.push({
-        label: dir,
-        description: fullPath.length > 100 ? '...' + fullPath.slice(-97) : fullPath,
-        value: dir,
-      });
-    }
-
-    const selectMenu = new StringSelectMenuBuilder()
-      .setCustomId('cc_workspace_browse')
-      .setPlaceholder('ディレクトリを選択してください')
-      .addOptions(options);
-
-    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
-  }
+  const workspaceCommands = createWorkspaceCommands({
+    workspaceStore,
+    workspaceBaseDir: config.workspaceBaseDir,
+  });
 
   // スラッシュコマンドイベント
   client.on(Events.InteractionCreate, async (interaction) => {
@@ -289,56 +252,11 @@ async function main(): Promise<void> {
     }
 
     // StringSelectMenu の選択イベント（/cc workspace add のディレクトリブラウズ）
-    if (interaction.isStringSelectMenu() && interaction.customId === 'cc_workspace_browse') {
-      const selected = interaction.values[0];
-      const state = browsingState.get(interaction.user.id);
-
-      if (!state) {
-        await interaction.update({
-          content:
-            'ブラウズセッションが期限切れです。再度 `/cc workspace add` を実行してください。',
-          components: [],
-        });
-        return;
-      }
-
-      if (selected === '__confirm__') {
-        // 現在のディレクトリをワークスペースとして登録
-        const wsName = state.customName || basename(state.currentPath);
-        browsingState.delete(interaction.user.id);
-        try {
-          workspaceStore.add({ name: wsName, path: state.currentPath });
-          await interaction.update({
-            content: `✅ ワークスペース「${wsName}」を登録しました (${state.currentPath})`,
-            components: [],
-          });
-        } catch (err) {
-          await interaction.update({
-            content: `⚠️ ${err instanceof Error ? err.message : '登録に失敗しました'}`,
-            components: [],
-          });
-        }
-        return;
-      }
-
-      if (selected === '__up__') {
-        state.currentPath = dirname(state.currentPath);
-      } else {
-        state.currentPath = join(state.currentPath, selected);
-      }
-
-      const row = buildBrowseMenu(state.currentPath);
-      if (row) {
-        await interaction.update({
-          content: `📂 ${state.currentPath}`,
-          components: [row],
-        });
-      } else {
-        await interaction.update({
-          content: `⚠️ ディレクトリの読み取りに失敗しました`,
-          components: [],
-        });
-      }
+    if (
+      interaction.isStringSelectMenu() &&
+      interaction.customId === workspaceCommands.browseCustomId
+    ) {
+      await workspaceCommands.handleBrowseSelect(interaction);
       return;
     }
 
@@ -373,81 +291,7 @@ async function main(): Promise<void> {
 
     // /cc workspace add|remove|list
     if (subcommandGroup === 'workspace') {
-      if (subcommand === 'add') {
-        const name = interaction.options.getString('name') ?? undefined;
-        const path = interaction.options.getString('path') ?? undefined;
-
-        // path が指定されている場合は直接登録
-        if (path) {
-          const wsName = name || basename(path);
-          try {
-            workspaceStore.add({ name: wsName, path });
-            await interaction.reply({
-              content: `✅ ワークスペース「${wsName}」を登録しました (${path})`,
-              ephemeral: true,
-            });
-          } catch (err) {
-            await interaction.reply({
-              content: `⚠️ ${err instanceof Error ? err.message : '登録に失敗しました'}`,
-              ephemeral: true,
-            });
-          }
-          return;
-        }
-
-        // path 省略 → ディレクトリブラウズモード
-        const startPath = config.workspaceBaseDir;
-        browsingState.set(interaction.user.id, { currentPath: startPath, customName: name });
-
-        const row = buildBrowseMenu(startPath);
-        if (row) {
-          await interaction.reply({
-            content: `📂 ${startPath}`,
-            components: [row],
-            ephemeral: true,
-          });
-        } else {
-          await interaction.reply({
-            content: '⚠️ ベースディレクトリの読み取りに失敗しました',
-            ephemeral: true,
-          });
-        }
-        return;
-      }
-
-      if (subcommand === 'remove') {
-        const name = interaction.options.getString('name', true);
-        const removed = workspaceStore.remove(name);
-        if (removed) {
-          await interaction.reply({
-            content: `✅ ワークスペース「${name}」を削除しました`,
-            ephemeral: true,
-          });
-        } else {
-          await interaction.reply({
-            content: `⚠️ ワークスペース「${name}」が見つかりません`,
-            ephemeral: true,
-          });
-        }
-        return;
-      }
-
-      if (subcommand === 'list') {
-        const workspaces = workspaceStore.list();
-        if (workspaces.length === 0) {
-          await interaction.reply({
-            content: 'ワークスペースが登録されていません。`/cc workspace add` で登録してください。',
-            ephemeral: true,
-          });
-        } else {
-          const lines = workspaces.map((w, i) => `${i + 1}. **${w.name}** — ${w.path}`);
-          await interaction.reply({
-            content: `📁 登録済みワークスペース:\n${lines.join('\n')}`,
-            ephemeral: true,
-          });
-        }
-        return;
-      }
+      await workspaceCommands.handleCommand(interaction);
       return;
     }
 


### PR DESCRIPTION
## Summary

- `/cc workspace` サブコマンド と `cc_workspace_browse` セレクトメニューのハンドラを `server/src/discord/commands/workspace.ts` に分離
- module-level の `browsingState` Map を新ファイル内にカプセル化

## 背景

親 issue #16 のリファクタリングの一環。`server/src/index.ts` を責務別に分割し Discord 固有コードを `discord/` 配下に整理する。

`/cc workspace` 関連処理は現状 `index.ts` の 4 箇所(303 行 Map、306-342 行 ヘルパ、473-524 行 ブラウズ select、556-632 行 コマンド本体)に散在しており、全貌把握や変更が困難。

## 変更内容

- **新規**: `server/src/discord/commands/workspace.ts` — `createWorkspaceCommands` ファクトリ(`handleCommand` / `handleBrowseSelect` / `browseCustomId`)
- **新規**: `server/src/discord/commands/workspace.test.ts` — ユニットテスト 17 ケース
- **`server/src/index.ts`**:
  - 303 行 `browsingState` Map / 306-342 行 `buildBrowseMenu` / 473-524 行 `cc_workspace_browse` ハンドラ / 556-632 行 `/cc workspace` ハンドラ を削除
  - `node:path` (`basename`, `dirname`, `join`) と `listDirectories` の import を削除(他で未使用)
  - 冒頭に `createWorkspaceCommands` の import を追加
  - `main()` 内で `createWorkspaceCommands({ workspaceStore, workspaceBaseDir: config.workspaceBaseDir })` を構築
  - `InteractionCreate` 内で `browseCustomId` 判定と `subcommandGroup === 'workspace'` 判定を呼び出しにディスパッチ

## テスト

- 新規 17 件、合計 497 件通過 (事前 480 件 → 事後 497 件)
- `workspace.ts` カバレッジ: Stmt 97.01% / Branch 86.84% / Func 100% / Line 96.96%
  - 未カバー行: 115, 202 — `buildBrowseMenu` が `null` を返した場合のフォールバック分岐。現行実装では `listDirectories` が `[]` の場合でも必ず `__confirm__` エントリで `ActionRowBuilder` を返すため、null 分岐は通常は到達不能なガード枝。既存仕様(`index.ts` からそのまま移設した戻り型 `| null`)を維持するため分岐自体は残した。

## 検証手順

```
cd server && pnpm install
pnpm run check          # typecheck + lint + format:check + test
pnpm run test:coverage
pnpm run build
```

## 注意事項

- Discord 実機での `/cc workspace add/list/remove` の動作確認は未実施。後続 Step 6 後の実機検証予定。
- 既存 3 パターン(session-factory/rewind-handler/message-controller)と同じ「`createXxx(deps): Fn` ファクトリ + discord.js 最小スタブモック」のスタイルで実装。

Closes #20
