### PR TITLE
refactor: /cc report を commands/report.ts に分離 (#24)

### DIFF
--- a/server/src/discord/commands/report.test.ts
+++ b/server/src/discord/commands/report.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
+import type { SessionSummary, Workspace } from '../../domain/types.js';
+import type { DailySession, IReportGenerator } from '../../infrastructure/report-generator.js';
+import type { ConversationEntry } from '../../infrastructure/session-reader.js';
+import { createReportCommand, sendReport, type ReportChannel } from './report.js';
+
+// helpers.ts の日付系関数はモックで時刻を固定
+vi.mock('../../helpers.js', async () => {
+  const actual = await vi.importActual<typeof import('../../helpers.js')>('../../helpers.js');
+  return {
+    ...actual,
+    todayJST: vi.fn(() => new Date('2026-04-21T00:00:00+09:00')),
+    log: vi.fn(),
+  };
+});
+
+vi.mock('../../infrastructure/session-reader.js', () => ({
+  readSession: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const readSessionModule: any = await import('../../infrastructure/session-reader.js');
+const mockedReadSession = readSessionModule.readSession as ReturnType<typeof vi.fn>;
+
+// ==============================
+// Autocomplete helpers
+// ==============================
+
+interface FocusedOption {
+  name: string;
+  value: string;
+}
+
+interface AutocompleteStub {
+  options: { getFocused: ReturnType<typeof vi.fn> };
+  respond: ReturnType<typeof vi.fn>;
+}
+
+function makeAutocomplete(focused: FocusedOption): AutocompleteStub {
+  return {
+    options: { getFocused: vi.fn(() => focused) },
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function coerceAutocomplete(a: AutocompleteStub): AutocompleteInteraction {
+  return a as unknown as AutocompleteInteraction;
+}
+
+// ==============================
+// Command helpers
+// ==============================
+
+interface CommandStub {
+  options: { getString: ReturnType<typeof vi.fn> };
+  reply: ReturnType<typeof vi.fn>;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
+}
+
+function makeCommand(dateArg: string | null = null): CommandStub {
+  return {
+    options: { getString: vi.fn(() => dateArg) },
+    reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function coerceCommand(c: CommandStub): ChatInputCommandInteraction {
+  return c as unknown as ChatInputCommandInteraction;
+}
+
+function makeWorkspaces(names: string[] = ['ws-a']): Workspace[] {
+  return names.map((name) => ({ name, path: `/work/${name}` }));
+}
+
+function makeSessionSummary(id: string, mtime: Date): SessionSummary {
+  return {
+    sessionId: id,
+    firstUserMessage: `first-${id}`,
+    slug: null,
+    lastModified: mtime,
+  };
+}
+
+function makeEntries(): ConversationEntry[] {
+  return [
+    { role: 'user', text: 'hello' },
+    { role: 'assistant', text: 'world' },
+  ];
+}
+
+interface ReportGenMock {
+  generate: ReturnType<typeof vi.fn>;
+}
+
+function makeReportGenerator(): ReportGenMock {
+  return {
+    generate: vi.fn().mockResolvedValue('## 日報\nbody'),
+  };
+}
+
+function coerceReportGenerator(m: ReportGenMock): IReportGenerator {
+  return m as unknown as IReportGenerator;
+}
+
+// ==============================
+// sendReport (単体)
+// ==============================
+
+describe('sendReport', () => {
+  let channel: { send: ReturnType<typeof vi.fn> };
+  let interaction: { editReply: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    channel = { send: vi.fn().mockResolvedValue(undefined) };
+    interaction = { editReply: vi.fn().mockResolvedValue(undefined) };
+  });
+
+  it('1000 文字 (≤2000): editReply のみで channel.send は呼ばない', async () => {
+    const report = 'x'.repeat(1000);
+    await sendReport(
+      interaction as unknown as ChatInputCommandInteraction,
+      channel as ReportChannel,
+      report,
+    );
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledWith(report);
+    expect(channel.send).not.toHaveBeenCalled();
+  });
+
+  it('ちょうど 2000 文字: editReply のみ', async () => {
+    const report = 'y'.repeat(2000);
+    await sendReport(
+      interaction as unknown as ChatInputCommandInteraction,
+      channel as ReportChannel,
+      report,
+    );
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledWith(report);
+    expect(channel.send).not.toHaveBeenCalled();
+  });
+
+  it('3500 文字 (2 分割): editReply 1 回 + channel.send 1 回', async () => {
+    const report = 'a'.repeat(2000) + 'b'.repeat(1500);
+    await sendReport(
+      interaction as unknown as ChatInputCommandInteraction,
+      channel as ReportChannel,
+      report,
+    );
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledWith('a'.repeat(2000));
+    expect(channel.send).toHaveBeenCalledTimes(1);
+    expect(channel.send).toHaveBeenCalledWith('b'.repeat(1500));
+  });
+
+  it('6500 文字 (4 分割): editReply 1 回 + channel.send 3 回で順序通り', async () => {
+    const chunk1 = 'a'.repeat(2000);
+    const chunk2 = 'b'.repeat(2000);
+    const chunk3 = 'c'.repeat(2000);
+    const chunk4 = 'd'.repeat(500);
+    const report = chunk1 + chunk2 + chunk3 + chunk4;
+
+    await sendReport(
+      interaction as unknown as ChatInputCommandInteraction,
+      channel as ReportChannel,
+      report,
+    );
+
+    expect(interaction.editReply).toHaveBeenCalledWith(chunk1);
+    expect(channel.send).toHaveBeenNthCalledWith(1, chunk2);
+    expect(channel.send).toHaveBeenNthCalledWith(2, chunk3);
+    expect(channel.send).toHaveBeenNthCalledWith(3, chunk4);
+    expect(channel.send).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ==============================
+// createReportCommand
+// ==============================
+
+describe('createReportCommand', () => {
+  let reportGenerator: ReportGenMock;
+  let workspaceStore: { list: ReturnType<typeof vi.fn> };
+  let sessionStore: { listSessionsByDateRange: ReturnType<typeof vi.fn> };
+  let channel: { send: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reportGenerator = makeReportGenerator();
+    workspaceStore = { list: vi.fn().mockReturnValue(makeWorkspaces()) };
+    sessionStore = {
+      listSessionsByDateRange: vi.fn().mockResolvedValue([]),
+    };
+    channel = { send: vi.fn().mockResolvedValue(undefined) };
+    mockedReadSession.mockResolvedValue(makeEntries());
+  });
+
+  function makeHandlers(options: { reportGeneratorNull?: boolean } = {}) {
+    return createReportCommand({
+      reportGenerator: options.reportGeneratorNull ? null : coerceReportGenerator(reportGenerator),
+      workspaceStore: workspaceStore as unknown as { list: () => Workspace[] },
+      sessionStore: sessionStore as unknown as {
+        listSessionsByDateRange: (
+          workDir: string,
+          from: Date,
+          to: Date,
+        ) => Promise<SessionSummary[]>;
+      },
+      channel: channel as ReportChannel,
+    });
+  }
+
+  // ----- handleAutocomplete -----
+
+  describe('handleAutocomplete', () => {
+    it('入力が空なら候補を 25 件上限でそのまま返す', async () => {
+      const { handleAutocomplete } = makeHandlers();
+      const ac = makeAutocomplete({ name: 'date', value: '' });
+
+      await handleAutocomplete(coerceAutocomplete(ac));
+
+      expect(ac.respond).toHaveBeenCalledTimes(1);
+      const arg = ac.respond.mock.calls[0][0] as { name: string; value: string }[];
+      expect(arg.length).toBeGreaterThan(0);
+      expect(arg.length).toBeLessThanOrEqual(25);
+    });
+
+    it('入力と一致する候補のみ返す (例: "昨日")', async () => {
+      const { handleAutocomplete } = makeHandlers();
+      const ac = makeAutocomplete({ name: 'date', value: '昨日' });
+
+      await handleAutocomplete(coerceAutocomplete(ac));
+
+      expect(ac.respond).toHaveBeenCalledTimes(1);
+      const arg = ac.respond.mock.calls[0][0] as { name: string; value: string }[];
+      expect(arg.every((c) => c.name.includes('昨日') || c.value.includes('昨日'))).toBe(true);
+      expect(arg.length).toBeGreaterThan(0);
+    });
+
+    it('入力と一致しない場合は空配列を返す', async () => {
+      const { handleAutocomplete } = makeHandlers();
+      const ac = makeAutocomplete({ name: 'date', value: 'zzz-no-match' });
+
+      await handleAutocomplete(coerceAutocomplete(ac));
+
+      expect(ac.respond).toHaveBeenCalledWith([]);
+    });
+
+    it('focused.name が date 以外なら respond を呼ばない (将来拡張ガード)', async () => {
+      const { handleAutocomplete } = makeHandlers();
+      const ac = makeAutocomplete({ name: 'workspace', value: 'any' });
+
+      await handleAutocomplete(coerceAutocomplete(ac));
+
+      expect(ac.respond).not.toHaveBeenCalled();
+    });
+  });
+
+  // ----- handleCommand -----
+
+  describe('handleCommand', () => {
+    it('reportGenerator が null なら ephemeral で案内し deferReply しない', async () => {
+      const { handleCommand } = makeHandlers({ reportGeneratorNull: true });
+      const cmd = makeCommand();
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.reply).toHaveBeenCalledWith({
+        content: '⚠️ 日報生成には GEMINI_API_KEY の設定が必要です',
+        ephemeral: true,
+      });
+      expect(cmd.deferReply).not.toHaveBeenCalled();
+      expect(cmd.editReply).not.toHaveBeenCalled();
+    });
+
+    it('deferReply は ephemeral 引数なしで呼ぶ (公開投稿)', async () => {
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand();
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.deferReply).toHaveBeenCalledTimes(1);
+      expect(cmd.deferReply).toHaveBeenCalledWith();
+    });
+
+    it('date 省略時は今日 (JST) を対象に listSessionsByDateRange を呼ぶ', async () => {
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand(null);
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(sessionStore.listSessionsByDateRange).toHaveBeenCalled();
+      // date 未指定で target は todayJST() = 2026-04-21 00:00 JST
+      // getDayBoundary で from = 2026-04-21 06:00 JST, to = 2026-04-22 06:00 JST
+      const [, from, to] = sessionStore.listSessionsByDateRange.mock.calls[0];
+      expect(from.toISOString()).toBe('2026-04-20T21:00:00.000Z');
+      expect(to.toISOString()).toBe('2026-04-21T21:00:00.000Z');
+    });
+
+    it('絶対日付 (YYYY-MM-DD) 指定が受理される', async () => {
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-01-15');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.editReply).toHaveBeenCalled();
+      const [, from] = sessionStore.listSessionsByDateRange.mock.calls[0];
+      expect(from.toISOString()).toBe('2026-01-14T21:00:00.000Z');
+    });
+
+    it('相対日付 (-1 = 昨日) 指定が受理される', async () => {
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('-1');
+
+      await handleCommand(coerceCommand(cmd));
+
+      const [, from] = sessionStore.listSessionsByDateRange.mock.calls[0];
+      // todayJST() = 2026-04-21, -1 → 2026-04-20, 06:00 JST = 2026-04-19T21:00Z
+      expect(from.toISOString()).toBe('2026-04-19T21:00:00.000Z');
+    });
+
+    it('不正な日付指定で editReply に警告を出し処理を止める', async () => {
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('invalid-date-string');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(sessionStore.listSessionsByDateRange).not.toHaveBeenCalled();
+      expect(cmd.editReply).toHaveBeenCalledWith(expect.stringContaining('日付の形式が不正'));
+    });
+
+    it('セッションが 0 件ならその旨を editReply して終了 (reportGenerator.generate は呼ばない)', async () => {
+      sessionStore.listSessionsByDateRange.mockResolvedValue([]);
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.editReply).toHaveBeenCalledWith(expect.stringContaining('見つかりません'));
+      expect(reportGenerator.generate).not.toHaveBeenCalled();
+    });
+
+    it('セッションあり: generate 結果 (≤2000 文字) を editReply で投稿', async () => {
+      workspaceStore.list.mockReturnValue(makeWorkspaces(['ws-a', 'ws-b']));
+      sessionStore.listSessionsByDateRange
+        .mockResolvedValueOnce([makeSessionSummary('s1', new Date('2026-04-21T10:00:00+09:00'))])
+        .mockResolvedValueOnce([
+          makeSessionSummary('s2', new Date('2026-04-21T11:00:00+09:00')),
+          makeSessionSummary('s3', new Date('2026-04-21T12:00:00+09:00')),
+        ]);
+      reportGenerator.generate.mockResolvedValue('短い日報');
+
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(mockedReadSession).toHaveBeenCalledTimes(3);
+      expect(reportGenerator.generate).toHaveBeenCalledTimes(1);
+      const [sessions, date] = reportGenerator.generate.mock.calls[0] as [DailySession[], Date];
+      expect(sessions).toHaveLength(3);
+      expect(sessions[0].title).toContain('[ws-a]');
+      expect(sessions[1].title).toContain('[ws-b]');
+      expect(date).toBeInstanceOf(Date);
+      expect(cmd.editReply).toHaveBeenCalledWith('短い日報');
+      expect(channel.send).not.toHaveBeenCalled();
+    });
+
+    it('全セッションの readSession が throw した場合 「読み込みに失敗」 を editReply', async () => {
+      const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      sessionStore.listSessionsByDateRange.mockResolvedValue([
+        makeSessionSummary('s1', new Date('2026-04-21T10:00:00+09:00')),
+      ]);
+      mockedReadSession.mockRejectedValue(new Error('read fail'));
+
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(reportGenerator.generate).not.toHaveBeenCalled();
+      expect(cmd.editReply).toHaveBeenCalledWith(expect.stringContaining('読み込みに失敗'));
+      consoleErrSpy.mockRestore();
+    });
+
+    it('generate 結果が 2000 文字超なら sendReport 経由で分割送信する', async () => {
+      sessionStore.listSessionsByDateRange.mockResolvedValue([
+        makeSessionSummary('s1', new Date('2026-04-21T10:00:00+09:00')),
+      ]);
+      const long = 'A'.repeat(2500);
+      reportGenerator.generate.mockResolvedValue(long);
+
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.editReply).toHaveBeenCalledWith('A'.repeat(2000));
+      expect(channel.send).toHaveBeenCalledTimes(1);
+      expect(channel.send).toHaveBeenCalledWith('A'.repeat(500));
+    });
+
+    it('try ブロック内で例外が起きても editReply で「エラーが発生」を案内する', async () => {
+      const consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      sessionStore.listSessionsByDateRange.mockRejectedValue(new Error('disk fail'));
+
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.editReply).toHaveBeenCalledWith(expect.stringContaining('エラーが発生'));
+      consoleErrSpy.mockRestore();
+    });
+
+    it('generate が null のときのメッセージ内容を確認', async () => {
+      sessionStore.listSessionsByDateRange.mockResolvedValue([
+        makeSessionSummary('s1', new Date('2026-04-21T10:00:00+09:00')),
+      ]);
+      reportGenerator.generate.mockResolvedValue(null);
+
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(cmd.editReply).toHaveBeenCalledWith(expect.stringContaining('日報の生成に失敗'));
+    });
+  });
+});

--- a/server/src/discord/commands/report.test.ts
+++ b/server/src/discord/commands/report.test.ts
@@ -390,6 +390,30 @@ describe('createReportCommand', () => {
       consoleErrSpy.mockRestore();
     });
 
+    it('一部セッションの readSession が throw しても、成功した分だけで generate を呼ぶ', async () => {
+      sessionStore.listSessionsByDateRange.mockResolvedValue([
+        makeSessionSummary('s1', new Date('2026-04-21T10:00:00+09:00')),
+        makeSessionSummary('s2', new Date('2026-04-21T11:00:00+09:00')),
+        makeSessionSummary('s3', new Date('2026-04-21T12:00:00+09:00')),
+      ]);
+      mockedReadSession
+        .mockResolvedValueOnce(makeEntries())
+        .mockRejectedValueOnce(new Error('broken jsonl for s2'))
+        .mockResolvedValueOnce(makeEntries());
+
+      const { handleCommand } = makeHandlers();
+      const cmd = makeCommand('2026-04-21');
+
+      await handleCommand(coerceCommand(cmd));
+
+      expect(reportGenerator.generate).toHaveBeenCalledTimes(1);
+      const [sessions] = reportGenerator.generate.mock.calls[0] as [DailySession[], Date];
+      expect(sessions).toHaveLength(2);
+      const titles = sessions.map((s) => s.title);
+      expect(titles.some((t) => t.includes('first-s1'))).toBe(true);
+      expect(titles.some((t) => t.includes('first-s3'))).toBe(true);
+    });
+
     it('generate 結果が 2000 文字超なら sendReport 経由で分割送信する', async () => {
       sessionStore.listSessionsByDateRange.mockResolvedValue([
         makeSessionSummary('s1', new Date('2026-04-21T10:00:00+09:00')),

--- a/server/src/discord/commands/report.ts
+++ b/server/src/discord/commands/report.ts
@@ -1,0 +1,183 @@
+import type { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
+import type { SessionSummary, Workspace } from '../../domain/types.js';
+import type { DailySession, IReportGenerator } from '../../infrastructure/report-generator.js';
+import { readSession } from '../../infrastructure/session-reader.js';
+import { getDayBoundary } from '../../infrastructure/session-store.js';
+import type { IWorkspaceStore } from '../../infrastructure/workspace-store.js';
+import { generateDateChoices, log, parseDateInput, todayJST } from '../../helpers.js';
+
+const DISCORD_MESSAGE_LIMIT = 2000;
+
+/** report を送信するチャンネル。TextChannel のうち send だけを利用。 */
+export interface ReportChannel {
+  send(content: string): Promise<unknown>;
+}
+
+/** report コマンドが使用する SessionStore の部分インターフェース。 */
+export interface ReportSessionStore {
+  listSessionsByDateRange(workDir: string, from: Date, to: Date): Promise<SessionSummary[]>;
+}
+
+export interface ReportCommandDeps {
+  reportGenerator: IReportGenerator | null;
+  workspaceStore: Pick<IWorkspaceStore, 'list'>;
+  sessionStore: ReportSessionStore;
+  channel: ReportChannel;
+}
+
+export interface ReportCommandHandlers {
+  handleCommand: (interaction: ChatInputCommandInteraction) => Promise<void>;
+  handleAutocomplete: (interaction: AutocompleteInteraction) => Promise<void>;
+}
+
+/**
+ * Discord の 2000 文字制限に合わせて日報を分割送信する。
+ *  - report.length <= 2000: editReply のみ
+ *  - それ以上: 先頭を editReply, 残りを channel.send
+ */
+export async function sendReport(
+  interaction: Pick<ChatInputCommandInteraction, 'editReply'>,
+  channel: ReportChannel,
+  report: string,
+): Promise<void> {
+  if (report.length <= DISCORD_MESSAGE_LIMIT) {
+    await interaction.editReply(report);
+    return;
+  }
+
+  const chunks: string[] = [];
+  let remaining = report;
+  while (remaining.length > 0) {
+    chunks.push(remaining.slice(0, DISCORD_MESSAGE_LIMIT));
+    remaining = remaining.slice(DISCORD_MESSAGE_LIMIT);
+  }
+  await interaction.editReply(chunks[0]);
+  for (let i = 1; i < chunks.length; i++) {
+    await channel.send(chunks[i]);
+  }
+}
+
+/**
+ * `/cc report` コマンド本体とオートコンプリートのハンドラを生成する。
+ *
+ * 処理の流れ (handleCommand):
+ *  1. reportGenerator が null (GEMINI_API_KEY 未設定) なら ephemeral で案内して終了
+ *  2. 公開応答として deferReply (ephemeral 指定なし) する
+ *  3. date 引数をパース。未指定なら今日 (JST)、不正なら編集応答で案内して終了
+ *  4. 対象日の [from, to) で全ワークスペースのセッションを収集
+ *  5. 0 件なら編集応答で案内して終了
+ *  6. 各セッション本文を読み込み、ReportGenerator.generate に渡す
+ *  7. 返ってきた文字列を sendReport で 2000 文字制限に収めて投稿
+ *
+ * handleAutocomplete は `focused.name === 'date'` 以外を早期 return し、
+ * 将来他コマンドにオートコンプリートを追加した際の衝突を避ける。
+ */
+export function createReportCommand(deps: ReportCommandDeps): ReportCommandHandlers {
+  const { reportGenerator, workspaceStore, sessionStore, channel } = deps;
+
+  const handleAutocomplete = async (interaction: AutocompleteInteraction): Promise<void> => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== 'date') return;
+
+    const choices = generateDateChoices();
+    const input = focused.value.toLowerCase();
+    const filtered = input
+      ? choices.filter((c) => c.name.includes(input) || c.value.includes(input))
+      : choices;
+    await interaction.respond(filtered.slice(0, 25));
+  };
+
+  const handleCommand = async (interaction: ChatInputCommandInteraction): Promise<void> => {
+    if (!reportGenerator) {
+      await interaction.reply({
+        content: '⚠️ 日報生成には GEMINI_API_KEY の設定が必要です',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    await interaction.deferReply();
+
+    try {
+      const dateStr = interaction.options.getString('date');
+      let targetDate: Date;
+
+      if (dateStr) {
+        const parsed = parseDateInput(dateStr);
+        if (!parsed) {
+          await interaction.editReply(
+            '⚠️ 日付の形式が不正です（YYYY-MM-DD または -1, -2 等の相対指定で入力してください）',
+          );
+          return;
+        }
+        targetDate = parsed;
+      } else {
+        targetDate = todayJST();
+      }
+
+      const { from, to } = getDayBoundary(targetDate);
+
+      // 全ワークスペースからセッションを収集
+      const workspaces = workspaceStore.list();
+      const allSessions: Array<{
+        workspace: Workspace;
+        sessions: Awaited<ReturnType<typeof sessionStore.listSessionsByDateRange>>;
+      }> = [];
+      for (const ws of workspaces) {
+        const sessions = await sessionStore.listSessionsByDateRange(ws.path, from, to);
+        if (sessions.length > 0) {
+          allSessions.push({ workspace: ws, sessions });
+        }
+      }
+
+      const totalCount = allSessions.reduce((sum, e) => sum + e.sessions.length, 0);
+      if (totalCount === 0) {
+        const dateLabel =
+          dateStr ?? targetDate.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' });
+        await interaction.editReply(`⚠️ ${dateLabel} のセッションが見つかりません`);
+        return;
+      }
+
+      log(`日報生成開始: ${totalCount} セッション (${allSessions.length} ワークスペース)`);
+
+      // 各セッションの会話を読み込み
+      const dailySessions: DailySession[] = [];
+      for (const { workspace: ws, sessions } of allSessions) {
+        for (const s of sessions) {
+          try {
+            const entries = await readSession(s.sessionId, ws.path);
+            dailySessions.push({
+              sessionId: s.sessionId,
+              title: `[${ws.name}] ${s.slug ?? s.firstUserMessage.slice(0, 50)}`,
+              messageCount: entries.length,
+              entries,
+            });
+          } catch {
+            log(`セッション読み込みスキップ: ${s.sessionId}`);
+          }
+        }
+      }
+
+      if (dailySessions.length === 0) {
+        await interaction.editReply('⚠️ セッションの読み込みに失敗しました');
+        return;
+      }
+
+      const report = await reportGenerator.generate(dailySessions, targetDate);
+
+      if (!report) {
+        await interaction.editReply('⚠️ 日報の生成に失敗しました');
+        return;
+      }
+
+      await sendReport(interaction, channel, report);
+
+      log('日報生成完了');
+    } catch (err) {
+      console.error('Report generation error:', err);
+      await interaction.editReply('⚠️ 日報の生成中にエラーが発生しました');
+    }
+  };
+
+  return { handleCommand, handleAutocomplete };
+}

--- a/server/src/discord/commands/report.ts
+++ b/server/src/discord/commands/report.ts
@@ -121,7 +121,7 @@ export function createReportCommand(deps: ReportCommandDeps): ReportCommandHandl
       const workspaces = workspaceStore.list();
       const allSessions: Array<{
         workspace: Workspace;
-        sessions: Awaited<ReturnType<typeof sessionStore.listSessionsByDateRange>>;
+        sessions: SessionSummary[];
       }> = [];
       for (const ws of workspaces) {
         const sessions = await sessionStore.listSessionsByDateRange(ws.path, from, to);
@@ -153,6 +153,7 @@ export function createReportCommand(deps: ReportCommandDeps): ReportCommandHandl
               entries,
             });
           } catch {
+            // 破損 JSONL などで個別セッションの読み込みが失敗しても、他セッションの日報生成は続ける
             log(`セッション読み込みスキップ: ${s.sessionId}`);
           }
         }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,9 +20,6 @@ import { SessionStore } from './infrastructure/session-store.js';
 import { ccCommand } from './infrastructure/slash-commands.js';
 import { TitleGenerator } from './infrastructure/title-generator.js';
 import { ReportGenerator } from './infrastructure/report-generator.js';
-import type { DailySession } from './infrastructure/report-generator.js';
-import { readSession } from './infrastructure/session-reader.js';
-import { getDayBoundary } from './infrastructure/session-store.js';
 import { UsageFetcher } from './infrastructure/usage-fetcher.js';
 import { SessionRestorer } from './infrastructure/session-restorer.js';
 import { ThreadMappingStore } from './infrastructure/thread-mapping-store.js';
@@ -32,13 +29,8 @@ import { WorkspaceStore, listDirectories } from './infrastructure/workspace-stor
 import { createSessionFactory, createPersistMapping } from './discord/session-factory.js';
 import { createRewindHandler } from './discord/rewind-handler.js';
 import { createMessageController } from './discord/message-controller.js';
-import {
-  formatRelativeDate,
-  todayJST,
-  parseDateInput,
-  generateDateChoices,
-  log,
-} from './helpers.js';
+import { createReportCommand } from './discord/commands/report.js';
+import { formatRelativeDate, log } from './helpers.js';
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -115,6 +107,13 @@ async function main(): Promise<void> {
   });
   client.on(Events.MessageCreate, messageController);
 
+  const reportCommand = createReportCommand({
+    reportGenerator,
+    workspaceStore,
+    sessionStore,
+    channel,
+  });
+
   // /cc new のワークスペース選択待ち中の options を一時保持
   const pendingNewOptions = new Map<string, import('./domain/types.js').SessionOptions>();
 
@@ -164,15 +163,7 @@ async function main(): Promise<void> {
   client.on(Events.InteractionCreate, async (interaction) => {
     // オートコンプリートイベント（/cc report の date）
     if (interaction.isAutocomplete() && interaction.commandName === 'cc') {
-      const focused = interaction.options.getFocused(true);
-      if (focused.name === 'date') {
-        const choices = generateDateChoices();
-        const input = focused.value.toLowerCase();
-        const filtered = input
-          ? choices.filter((c) => c.name.includes(input) || c.value.includes(input))
-          : choices;
-        await interaction.respond(filtered.slice(0, 25));
-      }
+      await reportCommand.handleAutocomplete(interaction);
       return;
     }
 
@@ -576,109 +567,7 @@ async function main(): Promise<void> {
 
     // /cc report — 日報を生成（全ワークスペース横断）
     if (subcommand === 'report') {
-      if (!reportGenerator) {
-        await interaction.reply({
-          content: '⚠️ 日報生成には GEMINI_API_KEY の設定が必要です',
-          ephemeral: true,
-        });
-        return;
-      }
-
-      await interaction.deferReply();
-
-      try {
-        const dateStr = interaction.options.getString('date');
-        let targetDate: Date;
-
-        if (dateStr) {
-          const parsed = parseDateInput(dateStr);
-          if (!parsed) {
-            await interaction.editReply(
-              '⚠️ 日付の形式が不正です（YYYY-MM-DD または -1, -2 等の相対指定で入力してください）',
-            );
-            return;
-          }
-          targetDate = parsed;
-        } else {
-          targetDate = todayJST();
-        }
-
-        const { from, to } = getDayBoundary(targetDate);
-
-        // 全ワークスペースからセッションを収集
-        const workspaces = workspaceStore.list();
-        const allSessions: Array<{
-          workspace: Workspace;
-          sessions: Awaited<ReturnType<typeof sessionStore.listSessionsByDateRange>>;
-        }> = [];
-        for (const ws of workspaces) {
-          const sessions = await sessionStore.listSessionsByDateRange(ws.path, from, to);
-          if (sessions.length > 0) {
-            allSessions.push({ workspace: ws, sessions });
-          }
-        }
-
-        const totalCount = allSessions.reduce((sum, e) => sum + e.sessions.length, 0);
-        if (totalCount === 0) {
-          const dateLabel =
-            dateStr ?? targetDate.toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' });
-          await interaction.editReply(`⚠️ ${dateLabel} のセッションが見つかりません`);
-          return;
-        }
-
-        log(`日報生成開始: ${totalCount} セッション (${allSessions.length} ワークスペース)`);
-
-        // 各セッションの会話を読み込み
-        const dailySessions: DailySession[] = [];
-        for (const { workspace: ws, sessions } of allSessions) {
-          for (const s of sessions) {
-            try {
-              const entries = await readSession(s.sessionId, ws.path);
-              dailySessions.push({
-                sessionId: s.sessionId,
-                title: `[${ws.name}] ${s.slug ?? s.firstUserMessage.slice(0, 50)}`,
-                messageCount: entries.length,
-                entries,
-              });
-            } catch {
-              log(`セッション読み込みスキップ: ${s.sessionId}`);
-            }
-          }
-        }
-
-        if (dailySessions.length === 0) {
-          await interaction.editReply('⚠️ セッションの読み込みに失敗しました');
-          return;
-        }
-
-        const report = await reportGenerator.generate(dailySessions, targetDate);
-
-        if (!report) {
-          await interaction.editReply('⚠️ 日報の生成に失敗しました');
-          return;
-        }
-
-        // Discord の文字数上限（2000文字）で分割送信
-        if (report.length <= 2000) {
-          await interaction.editReply(report);
-        } else {
-          const chunks: string[] = [];
-          let remaining = report;
-          while (remaining.length > 0) {
-            chunks.push(remaining.slice(0, 2000));
-            remaining = remaining.slice(2000);
-          }
-          await interaction.editReply(chunks[0]);
-          for (let i = 1; i < chunks.length; i++) {
-            await channel.send(chunks[i]);
-          }
-        }
-
-        log('日報生成完了');
-      } catch (err) {
-        console.error('Report generation error:', err);
-        await interaction.editReply('⚠️ 日報の生成中にエラーが発生しました');
-      }
+      await reportCommand.handleCommand(interaction);
       return;
     }
 


### PR DESCRIPTION
## Summary

- `/cc report` 本体 + オートコンプリート + 2000 文字分割送信ロジックを `server/src/discord/commands/report.ts` に集約
- `sendReport` を独立関数化し単体テスト可能に
- `GEMINI_API_KEY` 未設定時のガードも新ファイル内で処理

## 背景

親 issue #16 のリファクタリングの一環。`/cc report` は Step 5 の中で最も複雑(Gemini API 呼び出し、オートコンプリート、分割送信)で、`index.ts` に直書きされた状態ではテスト困難だった。

## 変更内容

- **新規**: `server/src/discord/commands/report.ts` — `createReportCommand` ファクトリ
  - `deferReply()` は ephemeral なし(公開投稿、issue #24 指示通り)
  - `handleAutocomplete` 冒頭で `focused.name === 'date'` のみ処理(将来拡張用)
  - `sendReport` を独立ヘルパーとして切り出し、2000 文字分割ロジックを独立化
- **新規**: `server/src/discord/commands/report.test.ts` — 20 ケース(分割送信 4 件 / autocomplete 4 件 / command 12 件)
- **`server/src/index.ts`**:
  - オートコンプリート処理(旧 166-177 行) / `/cc report` 本体(旧 578-683 行)を削除
  - import + `main()` 構築 + `InteractionCreate` 内ディスパッチ追加
  - 770 行 → 659 行 (111 行削減)

## テスト

- 新規 20 件、合計 500 件通過
- `report.ts` カバレッジ: Stmt 100% / Branch 100% / Func 100% / Line 100%

## 検証手順

```
cd server && pnpm install
pnpm run check
pnpm run test:coverage
pnpm run build
```

## 注意事項

- Discord 実機での `/cc report` 動作確認、および `GEMINI_API_KEY` 未設定環境での挙動確認は未実施。後続でまとめて検証予定。

Closes #24
