### PR TITLE
fix(test): report.test.ts の日付モックを setSystemTime 方式に変更

### DIFF
--- a/server/src/discord/commands/report.test.ts
+++ b/server/src/discord/commands/report.test.ts
@@ -1,18 +1,30 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
 import type { SessionSummary, Workspace } from '../../domain/types.js';
 import type { DailySession, IReportGenerator } from '../../infrastructure/report-generator.js';
 import type { ConversationEntry } from '../../infrastructure/session-reader.js';
 import { createReportCommand, sendReport, type ReportChannel } from './report.js';
 
-// helpers.ts の日付系関数はモックで時刻を固定
+// helpers.ts の log のみモック化。日付固定は vi.setSystemTime で行う
+// (todayJST を直接モックすると、helpers.ts 内の parseDateInput など他関数からの
+//  内部呼び出しがモックを経由せず実時刻を参照してしまうため)
 vi.mock('../../helpers.js', async () => {
   const actual = await vi.importActual<typeof import('../../helpers.js')>('../../helpers.js');
   return {
     ...actual,
-    todayJST: vi.fn(() => new Date('2026-04-21T00:00:00+09:00')),
     log: vi.fn(),
   };
+});
+
+// 全テストで現在時刻を 2026-04-21 12:00 JST に固定
+// (JST 06:00 前は todayJST() が前日扱いするため、安全に正午で固定)
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-21T12:00:00+09:00'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 vi.mock('../../infrastructure/session-reader.js', () => ({

--- a/server/src/helpers.test.ts
+++ b/server/src/helpers.test.ts
@@ -14,7 +14,7 @@ import type { UsageInfo } from './domain/types.js';
 describe('formatRelativeDate', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-22T12:00:00Z'));
+    vi.setSystemTime(new Date('2026-03-22T21:00:00+09:00'));
   });
 
   afterEach(() => {
@@ -22,27 +22,27 @@ describe('formatRelativeDate', () => {
   });
 
   it('1分未満は「たった今」', () => {
-    const date = new Date('2026-03-22T11:59:30Z');
+    const date = new Date('2026-03-22T20:59:30+09:00');
     expect(formatRelativeDate(date)).toBe('たった今');
   });
 
   it('1分〜60分未満は「N分前」', () => {
-    const date = new Date('2026-03-22T11:30:00Z');
+    const date = new Date('2026-03-22T20:30:00+09:00');
     expect(formatRelativeDate(date)).toBe('30分前');
   });
 
   it('1時間〜24時間未満は「N時間前」', () => {
-    const date = new Date('2026-03-22T06:00:00Z');
+    const date = new Date('2026-03-22T15:00:00+09:00');
     expect(formatRelativeDate(date)).toBe('6時間前');
   });
 
   it('1日〜30日未満は「N日前」', () => {
-    const date = new Date('2026-03-20T12:00:00Z');
+    const date = new Date('2026-03-20T21:00:00+09:00');
     expect(formatRelativeDate(date)).toBe('2日前');
   });
 
   it('30日以上は日付文字列', () => {
-    const date = new Date('2026-01-01T00:00:00Z');
+    const date = new Date('2026-01-01T09:00:00+09:00');
     const result = formatRelativeDate(date);
     expect(result).toMatch(/2026/);
   });
@@ -55,8 +55,7 @@ describe('todayJST', () => {
 
   it('JST 6時以降は当日を返す', () => {
     vi.useFakeTimers();
-    // UTC 00:00 = JST 09:00
-    vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+    vi.setSystemTime(new Date('2026-03-22T09:00:00+09:00'));
     const result = todayJST();
     const jstDate = new Date(result.getTime() + 9 * 60 * 60 * 1000);
     expect(jstDate.getUTCDate()).toBe(22);
@@ -64,8 +63,8 @@ describe('todayJST', () => {
 
   it('JST 6時前は前日扱い', () => {
     vi.useFakeTimers();
-    // UTC 20:00 = JST 翌日05:00 → 前日扱い
-    vi.setSystemTime(new Date('2026-03-21T20:00:00Z'));
+    // JST 05:00 → 前日扱い
+    vi.setSystemTime(new Date('2026-03-22T05:00:00+09:00'));
     const result = todayJST();
     const jstDate = new Date(result.getTime() + 9 * 60 * 60 * 1000);
     expect(jstDate.getUTCDate()).toBe(21);
@@ -97,14 +96,14 @@ describe('parseDateInput', () => {
 
   it('相対指定 0 は今日を返す', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+    vi.setSystemTime(new Date('2026-03-22T09:00:00+09:00'));
     const result = parseDateInput('0');
     expect(result).not.toBeNull();
   });
 
   it('相対指定 -1 は昨日を返す', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+    vi.setSystemTime(new Date('2026-03-22T09:00:00+09:00'));
     const today = parseDateInput('0');
     const yesterday = parseDateInput('-1');
     expect(today!.getTime() - yesterday!.getTime()).toBe(24 * 60 * 60 * 1000);
@@ -112,7 +111,7 @@ describe('parseDateInput', () => {
 
   it('相対指定 +1 は明日を返す', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+    vi.setSystemTime(new Date('2026-03-22T09:00:00+09:00'));
     const today = parseDateInput('0');
     const tomorrow = parseDateInput('+1');
     expect(tomorrow!.getTime() - today!.getTime()).toBe(24 * 60 * 60 * 1000);
@@ -126,7 +125,7 @@ describe('parseDateInput', () => {
 describe('generateDateChoices', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+    vi.setSystemTime(new Date('2026-03-22T09:00:00+09:00'));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

main ブランチで `相対日付 (-1 = 昨日) 指定が受理される` テストが日付ドリフトで失敗していた問題を修正。

## 失敗の原因

`helpers.todayJST` を `vi.fn(() => new Date(...))` で外部モックしていたが、同じ `helpers.ts` 内の `parseDateInput` が `todayJST()` を**モジュール内部参照**で呼び出しているため、モックを経由せず実 `new Date()` が使われていた。

```
parseDateInput('-1')
  └─ todayJST()        ← モジュール内部呼び出し、モック効かず
       └─ new Date()   ← 実日時を参照してドリフト
```

絶対日付 (`'2026-04-21'`) や `report.ts` 経由の `todayJST()` 呼び出し(モジュール跨ぎ)はモックが効くため通っていた。

## 修正方針

`vi.useFakeTimers()` + `vi.setSystemTime()` で `Date` 自体を固定する方式に変更。`real` な `todayJST` / `parseDateInput` 双方が同じ固定時刻を参照するようになる。

`todayJST()` には「JST 06:00 前は前日扱い」ロジックがあるため、固定時刻は安全マージンを取って正午 (12:00 JST) に設定。

## 変更点

- `vi.mock('../../helpers.js')` から `todayJST` の override を削除(`log` モックのみ残す)
- ファイル先頭に `beforeEach`/`afterEach` で `useFakeTimers` + `setSystemTime` を追加

## Test plan

- [x] `pnpm check` 全項目 (typecheck / lint / format / test) 通過
- [x] テスト 558 件すべてパス (失敗していた `相対日付 (-1 = 昨日)` を含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)